### PR TITLE
Fix errors made by changes to microbat

### DIFF
--- a/tregression/src/main/traceagent/handler/RunAllDefects4jHandler.java
+++ b/tregression/src/main/traceagent/handler/RunAllDefects4jHandler.java
@@ -24,6 +24,7 @@ import microbat.codeanalysis.runtime.InstrumentationExecutor;
 import microbat.codeanalysis.runtime.PreCheckInformation;
 import microbat.codeanalysis.runtime.RunningInformation;
 import microbat.codeanalysis.runtime.StepLimitException;
+import microbat.instrumentation.output.RunningInfo;
 import microbat.preference.AnalysisScopePreference;
 import microbat.util.MicroBatUtil;
 import sav.common.core.utils.SingleTimer;
@@ -138,7 +139,7 @@ public class RunAllDefects4jHandler  extends AbstractHandler {
 		InstrumentationExecutor executor = new InstrumentationExecutor(appClassPath, traceDir, traceName, includeLibs,
 				excludeLibs);
 		
-		RunningInformation info = null;
+		RunningInfo info = null;
 		try {
 			info = executor.run();
 		} catch (StepLimitException e) {

--- a/tregression/src/main/traceagent/report/BugCaseTrial.java
+++ b/tregression/src/main/traceagent/report/BugCaseTrial.java
@@ -5,6 +5,7 @@ package traceagent.report;
 
 import microbat.codeanalysis.runtime.PreCheckInformation;
 import microbat.codeanalysis.runtime.RunningInformation;
+import microbat.instrumentation.output.RunningInfo;
 import tregression.empiricalstudy.TestCase;
 
 /**
@@ -63,12 +64,12 @@ public class BugCaseTrial {
 
 	public static class TraceTrial {
 		private PreCheckInformation precheckInfo;
-		private RunningInformation runningInfo;
+		private RunningInfo runningInfo;
 		private long executionTime;
 		private String workingDir;
 		private boolean isBuggy;
 
-		public TraceTrial(String workingDir, PreCheckInformation precheckInfo, RunningInformation runningInfo,
+		public TraceTrial(String workingDir, PreCheckInformation precheckInfo, RunningInfo runningInfo,
 				long executionTime, boolean isBuggy) {
 			this.precheckInfo = precheckInfo;
 			this.runningInfo = runningInfo;
@@ -85,11 +86,11 @@ public class BugCaseTrial {
 			this.precheckInfo = precheckInfo;
 		}
 
-		public RunningInformation getRunningInfo() {
+		public RunningInfo getRunningInfo() {
 			return runningInfo;
 		}
 
-		public void setRunningInfo(RunningInformation runningInfo) {
+		public void setRunningInfo(RunningInfo runningInfo) {
 			this.runningInfo = runningInfo;
 		}
 


### PR DESCRIPTION
We reduce the number of duplicate classes by standardizing use of `RunningInfo` instead of `RunningInformation` throughout the codebase.
This may require developers to add `microbat_instrumentator` into the build path of `tregression`.