### PR TITLE
Add projects to defects4j handlers

### DIFF
--- a/tregression/src/main/traceagent/handler/RunAllDefects4jHandler.java
+++ b/tregression/src/main/traceagent/handler/RunAllDefects4jHandler.java
@@ -72,16 +72,18 @@ public class RunAllDefects4jHandler  extends AbstractHandler {
 	}
 
 	protected void runAll(String reportFile, IProgressMonitor monitor) throws Exception {
-		String[] projects = {"Chart", "Closure", "Lang", "Math", "Mockito", "Time"};
-		int[] bugNum = {26, 133, 65, 106, 38, 27};
+		String[] projects = {"Chart", "Cli", "Closure", "Codec",
+				"Collections", "Compress", "Csv", "Gson","JacksonCore", "JacksonDatabind",
+				"JacksonXml", "Jsoup", "JxPath", "Lang", "Math", "Mockito", "Time"};
+		int[] bugNum = {26, 40, 176, 18, 28, 47, 16, 18, 26, 112, 6, 93, 22, 65, 106, 38, 27};
 		AgentDefects4jReport report = new AgentDefects4jReport(new File(reportFile));
-		TestcaseFilter filter = new TestcaseFilter(false); 
+		TestcaseFilter filter = new TestcaseFilter(false);
 		for (int i = 0; i < projects.length; i++) {
 			String project = projects[i];
 			if (monitor.isCanceled()) {
 				return;
 			}
-			for (int j = 0; j <= bugNum[i]; j++) {
+			for (int j = 1; j <= bugNum[i]; j++) {
 				if (monitor.isCanceled()) {
 					return;
 				}
@@ -123,9 +125,9 @@ public class RunAllDefects4jHandler  extends AbstractHandler {
 				TraceTrial correctTrace = run(fixPath, tc, config, includeLibs, excludeLibs, false);
 				trial.setFixedTrace(correctTrace);
 			}
-			
 			report.record(trial);
 		}
+		
 	}
 	
 	public TraceTrial run(String workingDir, TestCase tc, Defects4jProjectConfig config, List<String> includeLibs,

--- a/tregression/src/main/traceagent/report/AgentDefects4jReport.java
+++ b/tregression/src/main/traceagent/report/AgentDefects4jReport.java
@@ -65,6 +65,4 @@ public class AgentDefects4jReport extends AbstractExcelWriter {
 		}
 		addCell(row, SUMMARY, traceTrial.getSummary());
 	}
-	
-	
 }

--- a/tregression/src/main/tregression/editors/CompareEditor.java
+++ b/tregression/src/main/tregression/editors/CompareEditor.java
@@ -159,12 +159,21 @@ public class CompareEditor extends EditorPart {
 	}
 
 	private void adjustTextForSelectedNode(TraceNode node, StyledText text, List<StyleRange> ranges) {
-		int topLine = node.getLineNumber()-15;
-		topLine = (topLine<1) ? 1 : topLine;
+		int topIndex = text.getTopIndex();
+		int bottomIndex = getPartiallyVisibleBottomIndex(text);
+		int numLinesDisplayed = Math.max(bottomIndex - topIndex, 1);
+		int topLine = node.getLineNumber() - numLinesDisplayed / 2 - 1;
+		topLine = (topLine < 2) ? 1 : topLine;
 		text.setTopIndex(topLine);
 		
 		StyleRange selectedRange = selectedLineStyle(text, node.getLineNumber()); 
 		ranges.add(selectedRange);
+	}
+	
+	private int getPartiallyVisibleBottomIndex(StyledText text) {
+		int clientAreaHeight = text.getClientArea().height;
+		int lastVisiblePixel = clientAreaHeight - 1;
+		return text.getLineIndex(lastVisiblePixel);
 	}
 	
 	public StyledText generateText(SashForm sashForm, String path, DiffMatcher matcher, final boolean isSource){

--- a/tregression/src/main/tregression/empiricalstudy/config/Defects4jProjectConfig.java
+++ b/tregression/src/main/tregression/empiricalstudy/config/Defects4jProjectConfig.java
@@ -19,8 +19,50 @@ public class Defects4jProjectConfig extends ProjectConfig{
 		if(projectName.equals("Chart")) {
 			config = new Defects4jProjectConfig("tests", "source", "build-tests", "build", "build", projectName, regressionID);
 		}
+		else if (projectName.equals("Cli")) {
+			if (bugID < 30) {
+				config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+			}
+			else {
+				config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+			}
+		}
 		else if (projectName.equals("Closure")) {
 			config = new Defects4jProjectConfig("test", "src", "build"+File.separator+"test", "build"+File.separator+"classes", "build", projectName, regressionID);
+		}
+		else if (projectName.equals("Codec")) {
+			if (bugID<11) {
+				config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"java", "target"+File.separator+"tests", "target"+File.separator+"classes", "target", projectName, regressionID);
+			} else {
+				config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"tests", "target"+File.separator+"classes", "target", projectName, regressionID);
+			}
+		}
+		else if (projectName.equals("Collections")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"main", "target"+File.separator+"tests", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("Compress")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("Csv")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("Gson")) {
+			config = new Defects4jProjectConfig("gson"+File.separator+"src"+File.separator+"test"+File.separator+"java", "gson"+File.separator+"src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("JacksonCore")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("JacksonDatabind")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("JacksonXml")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("Jsoup")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test"+File.separator+"java", "src"+File.separator+"main"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
+		}
+		else if (projectName.equals("JxPath")) {
+			config = new Defects4jProjectConfig("src"+File.separator+"test", "src"+File.separator+"java", "target"+File.separator+"test-classes", "target"+File.separator+"classes", "target", projectName, regressionID);
 		}
 		else if (projectName.equals("Lang")) {
 			if(bugID<21){

--- a/tregression/src/main/tregression/handler/AllDefects4jHandler.java
+++ b/tregression/src/main/tregression/handler/AllDefects4jHandler.java
@@ -42,9 +42,8 @@ public class AllDefects4jHandler extends AbstractHandler {
 				int skippedNum = 0;
 				int endNum = 500;
 				
-				String[] projects = {"Chart", "Closure", "Lang", "Math", "Mockito", "Time"};
-				int[] bugNum = {26, 133, 65, 106, 38, 27};
-				
+				String[] projects = {"Chart", "Cli", "Closure", "Codec", "Collections", "Compress", "Csv", "Gson","JacksonCore", "JacksonDatabind", "JacksonXml", "Jsoup", "JxPath", "Lang", "Math", "Mockito", "Time"};
+				int[] bugNum = {26, 40, 176, 18, 28, 47, 16, 18, 26, 112, 6, 93, 22, 65, 106, 38, 27};
 //				String fileName = "defects4j0.old.xlsx";
 				String fileName = "benchmark" + File.separator + "ben.xlsx";
 				Map<ReadEmpiricalTrial, ReadEmpiricalTrial> map = new HashMap<>();
@@ -154,7 +153,7 @@ public class AllDefects4jHandler extends AbstractHandler {
 							&& new File(oldDefects4jFile).exists()) {
 						Map<String, List<String>> keys = new HashMap<String, List<String>>();
 						keys.put("data", Arrays.asList("project", "bug_ID"));
-						ExperimentReportComparisonReporter.reportChange("defects4j_compare.xlsx", oldDefects4jFile, defects4jFile.getAbsolutePath(), 
+						ExperimentReportComparisonReporter.reportChange("defects4j_compare.xlsx", oldDefects4jFile, defects4jFile.getAbsolutePath(),
 									Arrays.asList(new TextComparisonRule(null), new SimulatorComparisonRule()), keys);
 					}
 				}


### PR DESCRIPTION
- Add new Defects4j projects to the Defects4j handlers and Defects4jProjectConfig.
- Update Tregression's Compare Editor to ensure the current trace line in the text editor is always visible (middle of the text editor), instead of the fixed 15 lines from the top.