### PR TITLE
Fix/missing file

### DIFF
--- a/tregression/src/main/tregression/separatesnapshots/DiffMatcher.java
+++ b/tregression/src/main/tregression/separatesnapshots/DiffMatcher.java
@@ -312,6 +312,7 @@ public class DiffMatcher {
 	}
 
 	private int countLineNumber(String fileName){
+		if (fileName.equals(DiffParser.ADDED_OR_REMOVED_FILE_NAME)) return 0;
 		LineNumberReader lnr;
 		try {
 			File file = new File(fileName);
@@ -415,7 +416,7 @@ public class DiffMatcher {
 
 	private boolean checkFollowByAdd(DiffChunk chunk, int startIndex, int successiveRemoveLines) {
 		int index = startIndex+successiveRemoveLines;
-		if(index <= chunk.getChangeList().size()){
+		if(index < chunk.getChangeList().size()){
 			return chunk.getChangeList().get(index).getType()==LineChange.ADD;
 		}
 		

--- a/tregression/src/main/tregression/separatesnapshots/diff/DiffParser.java
+++ b/tregression/src/main/tregression/separatesnapshots/diff/DiffParser.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DiffParser {
+	public static String ADDED_OR_REMOVED_FILE_NAME = "/dev/null";
+	
 	public List<FilePairWithDiff> parseDiff(List<String> diffContent, String sourceFolderName){
 		List<FilePairWithDiff> fileDiffList = new ArrayList<>();
 		FilePairWithDiff fileDiff = null;
@@ -78,8 +80,8 @@ public class DiffParser {
 			diffSuffix = "b/";
 		}
 		String resultFilePath;
-		if (line.contains("dev/null")) {
-			resultFilePath = "";
+		if (line.contains(ADDED_OR_REMOVED_FILE_NAME)) {
+			resultFilePath = ADDED_OR_REMOVED_FILE_NAME;
 		} else {
 			String osName = System.getProperty("os.name");
 			if(osName.contains("Win")){

--- a/tregression/src/main/tregression/separatesnapshots/diff/DiffParser.java
+++ b/tregression/src/main/tregression/separatesnapshots/diff/DiffParser.java
@@ -18,30 +18,10 @@ public class DiffParser {
 				fileDiff.setSourceFolderName(sourceFolderName);
 			}
 			else if(line.startsWith("---")){
-				String osName = System.getProperty("os.name");
-				String sourceFile;
-				if(osName.contains("Win")){
-					sourceFile = line.substring(line.indexOf("a/")+2, line.length()-1);
-				}
-				else{
-					sourceFile = line.substring(line.indexOf("a/")+1, line.length());
-				}
-				sourceFile = sourceFile.replace("/", File.separator);
-				sourceFile = sourceFile.replace("\\\\", File.separator);
-				fileDiff.setSourceFile(sourceFile);
+				fileDiff.setSourceFile(getFilePath(true, line));
 			}
 			else if(line.startsWith("+++")){
-				String osName = System.getProperty("os.name");
-				String targetFile;
-				if(osName.contains("Win")){
-					targetFile = line.substring(line.indexOf("b/")+2, line.length()-1);
-				}
-				else{
-					targetFile = line.substring(line.indexOf("b/")+1, line.length());
-				}
-				targetFile = targetFile.replace("/", File.separator);
-				targetFile = targetFile.replace("\\\\", File.separator);
-				fileDiff.setTargetFile(targetFile);
+				fileDiff.setTargetFile(getFilePath(false, line));
 			}
 			else if(line.startsWith("@@")){
 				String chunkInfo = line.substring(line.indexOf("@@")+3, line.lastIndexOf("@@")-1);
@@ -88,5 +68,29 @@ public class DiffParser {
 		}
 		
 		return -1;
+	}
+	
+	private String getFilePath(boolean isSource, String line) {
+		String diffSuffix = "";
+		if (isSource) {
+			diffSuffix = "a/";
+		} else {
+			diffSuffix = "b/";
+		}
+		String resultFilePath;
+		if (line.contains("dev/null")) {
+			resultFilePath = "";
+		} else {
+			String osName = System.getProperty("os.name");
+			if(osName.contains("Win")){
+				resultFilePath = line.substring(line.indexOf(diffSuffix)+2, line.length()-1);
+			}
+			else{
+				resultFilePath = line.substring(line.indexOf(diffSuffix)+1, line.length());
+			}
+			resultFilePath = resultFilePath.replace("/", File.separator);
+			resultFilePath = resultFilePath.replace("\\\\", File.separator);
+		}
+		return resultFilePath;
 	}
 }

--- a/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
+++ b/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
@@ -41,6 +41,11 @@ public class FilePairWithDiff {
 	
 	public String getDeclaringCompilationUnit(String path, String sourceFolderName){
 		if (path.equals(DiffParser.ADDED_OR_REMOVED_FILE_NAME)) return UNKNOWN_COMPILATION_UNIT;
+		int indexOfJava = path.indexOf(".java");
+		if (indexOfJava == -1) {
+		    // Not a java file then return empty str as the class name
+		    return "";
+		}
 		String path0 = path.substring(path.indexOf(sourceFolderName)+sourceFolderName.length()+1, path.indexOf(".java"));
 		String qualifier = path0.replace(File.separatorChar, '.');
 		

--- a/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
+++ b/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
@@ -11,7 +11,7 @@ import java.util.List;
  *
  */
 public class FilePairWithDiff {
-	
+	public static String UNKNOWN_COMPILATION_UNIT = "UNKNOWN_COMPILATION_UNIT";
 	private HashMap<Integer, List<Integer>> sourceToTargetMap = new HashMap<>();
 	private HashMap<Integer, List<Integer>> targetToSourceMap = new HashMap<>();
 	
@@ -40,7 +40,7 @@ public class FilePairWithDiff {
 	}
 	
 	public String getDeclaringCompilationUnit(String path, String sourceFolderName){
-		if (path.isEmpty()) return "";
+		if (path.equals(DiffParser.ADDED_OR_REMOVED_FILE_NAME)) return UNKNOWN_COMPILATION_UNIT;
 		String path0 = path.substring(path.indexOf(sourceFolderName)+sourceFolderName.length()+1, path.indexOf(".java"));
 		String qualifier = path0.replace(File.separatorChar, '.');
 		

--- a/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
+++ b/tregression/src/main/tregression/separatesnapshots/diff/FilePairWithDiff.java
@@ -40,6 +40,7 @@ public class FilePairWithDiff {
 	}
 	
 	public String getDeclaringCompilationUnit(String path, String sourceFolderName){
+		if (path.isEmpty()) return "";
 		String path0 = path.substring(path.indexOf(sourceFolderName)+sourceFolderName.length()+1, path.indexOf(".java"));
 		String qualifier = path0.replace(File.separatorChar, '.');
 		


### PR DESCRIPTION
Close #19 
When `git diff` recognizes a new or deleted file, it prints `/dev/null` as the file path. This was not handled in tregression.
Now it no longer crashes, and their LineChange Type is `LineChange.SRC`.

Changes made:
- DiffParser#parseDiff: Checks if file path contains `/dev/null`, and sets the file path of the new diff object to `/dev/null`
- FilePairWithDiff#getDeclaringCompilationUnit:  Checks if path is `/dev/null`, then returns `UNKNOWN_COMPILATION_UNIT` constant
- DiffMatcher#countLines: Checks if file name is `/dev/null`, and returns 0 