### PR TITLE
Update IODetector to handle wrong branch and add node number

### DIFF
--- a/tregression/main/iodetection/IODetector.java
+++ b/tregression/main/iodetection/IODetector.java
@@ -57,7 +57,7 @@ public class IODetector {
 
     /**
      * Iterates from the last node to first node, and checks for wrong variable
-     * value. Once it is found, it is returned.
+     * value or wrong branch. Once it is found, it is returned.
      * 
      * @return
      */
@@ -66,6 +66,11 @@ public class IODetector {
         int lastNodeOrder = buggyTrace.getLatestNode().getOrder();
         for (int i = lastNodeOrder; i >= 1; i--) {
             node = buggyTrace.getTraceNode(i);
+            TraceNodePair pair = pairList.findByBeforeNode(node);
+            // Check for wrong branch (no corresponding node in correct trace)
+            if (pair == null) {
+                return Optional.of(new NodeVarValPair(node, null));
+            }
             Optional<NodeVarValPair> wrongVariableOptional = getWrongVariableInNode(node);
             if (wrongVariableOptional.isEmpty()) {
                 continue;
@@ -80,7 +85,7 @@ public class IODetector {
      * dependencies to identify inputs.
      * 
      * @param outputNode
-     * @param output
+     * @param output The VarValue that had wrong value, or null if the output is a TraceNode that was wrongly executed.
      * @return
      */
     List<NodeVarValPair> detectInputVarValsFromOutput(TraceNode outputNode, VarValue output) {
@@ -222,8 +227,7 @@ public class IODetector {
             NodeVarValPair other = (NodeVarValPair) obj;
             return Objects.equals(node, other.node) && Objects.equals(varVal, other.varVal);
         }
-        
-        
+
     }
 
     public static class IOResult {

--- a/tregression/main/iodetection/IODetector.java
+++ b/tregression/main/iodetection/IODetector.java
@@ -1,6 +1,7 @@
 package iodetection;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.ArrayList;
@@ -28,191 +29,219 @@ import tregression.model.TraceNodePair;
  */
 public class IODetector {
 
-	private final Trace buggyTrace;
-	private final String testDir;
-	private final PairList pairList;
+    private final Trace buggyTrace;
+    private final String testDir;
+    private final PairList pairList;
 
-	public IODetector(Trace buggyTrace, String testDir, PairList pairList) {
-		this.buggyTrace = buggyTrace;
-		this.testDir = testDir;
-		this.pairList = pairList;
-	}
+    public IODetector(Trace buggyTrace, String testDir, PairList pairList) {
+        this.buggyTrace = buggyTrace;
+        this.testDir = testDir;
+        this.pairList = pairList;
+    }
 
-	/**
-	 * Runs IO detection.
-	 * @return
-	 */
-	public Optional<IOResult> detect() {
-		Optional<NodeVarValPair> outputNodeAndVarValOpt = detectOutput();
-		if (outputNodeAndVarValOpt.isEmpty()) {
-			return Optional.empty();
-		}
-		NodeVarValPair outputNodeAndVarVal = outputNodeAndVarValOpt.get();
-		VarValue output = outputNodeAndVarVal.getVarVal();
-		List<VarValue> inputs = detectInputVarValsFromOutput(outputNodeAndVarVal.getNode(), output);
-		return Optional.of(new IOResult(inputs, output));
-	}
+    /**
+     * Runs IO detection.
+     * 
+     * @return
+     */
+    public Optional<IOResult> detect() {
+        Optional<NodeVarValPair> outputNodeAndVarValOpt = detectOutput();
+        if (outputNodeAndVarValOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        NodeVarValPair outputNodeAndVarVal = outputNodeAndVarValOpt.get();
+        VarValue output = outputNodeAndVarVal.getVarVal();
+        List<NodeVarValPair> inputs = detectInputVarValsFromOutput(outputNodeAndVarVal.getNode(), output);
+        return Optional.of(new IOResult(inputs, outputNodeAndVarVal));
+    }
 
-	/**
-	 * Iterates from the last node to first node, and checks for wrong variable
-	 * value. Once it is found, it is returned.
-	 * 
-	 * @return
-	 */
-	Optional<NodeVarValPair> detectOutput() {
-		TraceNode node;
-		int lastNodeOrder = buggyTrace.getLatestNode().getOrder();
-		for (int i = lastNodeOrder; i >= 1; i--) {
-			node = buggyTrace.getTraceNode(i);
-			Optional<NodeVarValPair> wrongVariableOptional = getWrongVariableInNode(node);
-			if (wrongVariableOptional.isEmpty()) {
-				continue;
-			}
-			return wrongVariableOptional;
-		}
-		return Optional.empty();
-	}
+    /**
+     * Iterates from the last node to first node, and checks for wrong variable
+     * value. Once it is found, it is returned.
+     * 
+     * @return
+     */
+    Optional<NodeVarValPair> detectOutput() {
+        TraceNode node;
+        int lastNodeOrder = buggyTrace.getLatestNode().getOrder();
+        for (int i = lastNodeOrder; i >= 1; i--) {
+            node = buggyTrace.getTraceNode(i);
+            Optional<NodeVarValPair> wrongVariableOptional = getWrongVariableInNode(node);
+            if (wrongVariableOptional.isEmpty()) {
+                continue;
+            }
+            return wrongVariableOptional;
+        }
+        return Optional.empty();
+    }
 
-	/**
-	 * Given an output, it uses data, control and method invocation parent dependencies to identify inputs.
-	 * @param outputNode
-	 * @param output
-	 * @return
-	 */
-	List<VarValue> detectInputVarValsFromOutput(TraceNode outputNode, VarValue output) {
-		Set<VarValue> result = new HashSet<>();
-		detectInputVarValsFromOutput(outputNode, result, new HashSet<Integer>());
-		assert !result.contains(output);
-		return new ArrayList<>(result);
-	}
+    /**
+     * Given an output, it uses data, control and method invocation parent
+     * dependencies to identify inputs.
+     * 
+     * @param outputNode
+     * @param output
+     * @return
+     */
+    List<NodeVarValPair> detectInputVarValsFromOutput(TraceNode outputNode, VarValue output) {
+        Set<NodeVarValPair> result = new HashSet<>();
+        Set<VarValue> inputs = new HashSet<>();
+        detectInputVarValsFromOutput(outputNode, inputs, result, new HashSet<>());
+        assert !inputs.contains(output);
+        return new ArrayList<>(result);
+    }
 
-	// For each node, add the following as inputs (Variables in test file only)
-	// 1. Written variables.
-	// 2. read variables without data dominators
-	//
-	// Recurse on the following:
-	// 1. Data dominator on each read variable
-	// 2. Control/Invocation Parent
-	void detectInputVarValsFromOutput(TraceNode outputNode, Set<VarValue> inputs, Set<Integer> visited) {
-		int key = formVisitedKey(outputNode);
-		if (visited.contains(key)) {
-			return;
-		}
-		visited.add(key);
-		boolean isTestFile = isInTestDir(outputNode.getBreakPoint().getFullJavaFilePath());
-		if (isTestFile) {
-			// TODO: check if reference, then use heap address. (math_70 bug id 5)
-			// Check primitive variables, compare with correct trace's aligned node
-			List<VarValue> newInputs = new ArrayList<>(outputNode.getWrittenVariables());
-			Optional<NodeVarValPair> wrongVariable = getWrongVariableInNode(outputNode);
-			if (wrongVariable.isPresent()) {
-				VarValue incorrectValue = wrongVariable.get().getVarVal();
-				newInputs.remove(incorrectValue);
-			}
-			inputs.addAll(newInputs);
-		}
+    // For each node, add the following as inputs (Variables in test file only)
+    // 1. Written variables.
+    // 2. read variables without data dominators
+    //
+    // Recurse on the following:
+    // 1. Data dominator on each read variable
+    // 2. Control/Invocation Parent
+    void detectInputVarValsFromOutput(TraceNode outputNode, Set<VarValue> inputs, Set<NodeVarValPair> inputsWithNodes,
+            Set<Integer> visited) {
+        int key = formVisitedKey(outputNode);
+        if (visited.contains(key)) {
+            return;
+        }
+        visited.add(key);
+        boolean isTestFile = isInTestDir(outputNode.getBreakPoint().getFullJavaFilePath());
+        if (isTestFile) {
+            // TODO: check if reference, then use heap address. (math_70 bug id 5)
+            // Check primitive variables, compare with correct trace's aligned node
+            List<VarValue> newInputs = new ArrayList<>(outputNode.getWrittenVariables());
+            Optional<NodeVarValPair> wrongVariable = getWrongVariableInNode(outputNode);
+            if (wrongVariable.isPresent()) {
+                VarValue incorrectValue = wrongVariable.get().getVarVal();
+                newInputs.remove(incorrectValue);
+            }
+            newInputs.forEach(newInput -> {
+                if (!inputs.contains(newInput)) {
+                    inputsWithNodes.add(new NodeVarValPair(outputNode, newInput));
+                    inputs.add(newInput);
+                }
+            });
+        }
 
-		for (VarValue readVarVal : outputNode.getReadVariables()) {
-			TraceNode dataDominator = buggyTrace.findDataDependency(outputNode, readVarVal);
-			if (dataDominator == null && isTestFile) {
-				inputs.add(readVarVal);
-			}
-			if (dataDominator != null) {
-				detectInputVarValsFromOutput(dataDominator, inputs, visited);
-			}
-		}
-		TraceNode controlDominator = outputNode.getInvocationMethodOrDominator();
-		if (controlDominator != null) {
-			detectInputVarValsFromOutput(controlDominator, inputs, visited);
-		}
-	}
+        for (VarValue readVarVal : outputNode.getReadVariables()) {
+            TraceNode dataDominator = buggyTrace.findDataDependency(outputNode, readVarVal);
+            if (dataDominator == null && isTestFile && !inputs.contains(readVarVal)) {
+                inputs.add(readVarVal);
+                inputsWithNodes.add(new NodeVarValPair(outputNode, readVarVal));
+            }
+            if (dataDominator != null) {
+                detectInputVarValsFromOutput(dataDominator, inputs, inputsWithNodes, visited);
+            }
+        }
+        TraceNode controlDominator = outputNode.getInvocationMethodOrDominator();
+        if (controlDominator != null) {
+            detectInputVarValsFromOutput(controlDominator, inputs, inputsWithNodes, visited);
+        }
+    }
 
-	private int formVisitedKey(TraceNode node) {
-		return node.getOrder();
-	}
+    private int formVisitedKey(TraceNode node) {
+        return node.getOrder();
+    }
 
-	private boolean isInTestDir(String filePath) {
-		return filePath.contains(testDir);
-	}
+    private boolean isInTestDir(String filePath) {
+        return filePath.contains(testDir);
+    }
 
-	/**
-	 * Use PairList code to get wrong VarValues in the current node. Do not add
-	 * non-null ReferenceValue, as they are always correct.
-	 * 
-	 * @param node
-	 * @return
-	 */
-	private Optional<NodeVarValPair> getWrongVariableInNode(TraceNode node) {
-		TraceNodePair pair = pairList.findByBeforeNode(node);
-		if (pair == null) {
-			return Optional.empty();
-		}
-		List<VarValue> result = pair.findSingleWrongWrittenVarID(buggyTrace, pairList);
-		Optional<NodeVarValPair> wrongWrittenVar = getWrongVarFromVarList(result, node);
-		if (wrongWrittenVar.isPresent()) {
-			return wrongWrittenVar;
-		}
-		result = pair.findSingleWrongReadVar(buggyTrace, pairList);
-		Optional<NodeVarValPair> wrongReadVar = getWrongVarFromVarList(result, node);
-		return wrongReadVar;
-	}
+    /**
+     * Use PairList code to get wrong VarValues in the current node. Do not add
+     * non-null ReferenceValue, as they are always correct.
+     * 
+     * @param node
+     * @return
+     */
+    private Optional<NodeVarValPair> getWrongVariableInNode(TraceNode node) {
+        TraceNodePair pair = pairList.findByBeforeNode(node);
+        if (pair == null) {
+            return Optional.empty();
+        }
+        List<VarValue> result = pair.findSingleWrongWrittenVarID(buggyTrace, pairList);
+        Optional<NodeVarValPair> wrongWrittenVar = getWrongVarFromVarList(result, node);
+        if (wrongWrittenVar.isPresent()) {
+            return wrongWrittenVar;
+        }
+        result = pair.findSingleWrongReadVar(buggyTrace, pairList);
+        return getWrongVarFromVarList(result, node);
+    }
 
-	/**
-	 * Check the "incorrect" var values in the list, and return it if it is null or
-	 * primitive values.
-	 * 
-	 * @param varValues
-	 * @param node
-	 * @return
-	 */
-	private Optional<NodeVarValPair> getWrongVarFromVarList(List<VarValue> varValues, TraceNode node) {
-		for (VarValue varValue : varValues) {
-			if (varValue instanceof ReferenceValue) {
-				long addr = ((ReferenceValue) varValue).getUniqueID();
-				if (addr != -1) { // If the "incorrect" ref var value is not null, don't return it.
-					continue;
-				}
-			}
-			return Optional.of(new NodeVarValPair(node, varValue));
-		}
-		return Optional.empty();
-	}
+    /**
+     * Check the "incorrect" var values in the list, and return it if it is null or
+     * primitive values.
+     * 
+     * @param varValues
+     * @param node
+     * @return
+     */
+    private Optional<NodeVarValPair> getWrongVarFromVarList(List<VarValue> varValues, TraceNode node) {
+        for (VarValue varValue : varValues) {
+            if (varValue instanceof ReferenceValue) {
+                long addr = ((ReferenceValue) varValue).getUniqueID();
+                if (addr != -1) { // If the "incorrect" ref var value is not null, don't return it.
+                    continue;
+                }
+            }
+            return Optional.of(new NodeVarValPair(node, varValue));
+        }
+        return Optional.empty();
+    }
 
-	static class NodeVarValPair {
-		private final TraceNode node;
-		private final VarValue varVal;
+    public static class NodeVarValPair {
+        private final TraceNode node;
+        private final VarValue varVal;
 
-		public NodeVarValPair(TraceNode node, VarValue varVal) {
-			this.node = node;
-			this.varVal = varVal;
-		}
+        public NodeVarValPair(TraceNode node, VarValue varVal) {
+            this.node = node;
+            this.varVal = varVal;
+        }
 
-		public TraceNode getNode() {
-			return node;
-		}
+        public TraceNode getNode() {
+            return node;
+        }
 
-		public VarValue getVarVal() {
-			return varVal;
-		}
-	}
+        public VarValue getVarVal() {
+            return varVal;
+        }
 
-	public static class IOResult {
-		private final List<VarValue> inputs;
-		private final VarValue output;
+        @Override
+        public int hashCode() {
+            return Objects.hash(node, varVal);
+        }
 
-		public IOResult(List<VarValue> inputs, VarValue output) {
-			super();
-			this.inputs = inputs;
-			this.output = output;
-		}
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            NodeVarValPair other = (NodeVarValPair) obj;
+            return Objects.equals(node, other.node) && Objects.equals(varVal, other.varVal);
+        }
+        
+        
+    }
 
-		public List<VarValue> getInputs() {
-			return inputs;
-		}
+    public static class IOResult {
+        private final List<NodeVarValPair> inputs;
+        private final NodeVarValPair output;
 
-		public VarValue getOutput() {
-			return output;
-		}
+        public IOResult(List<NodeVarValPair> inputs, NodeVarValPair output) {
+            super();
+            this.inputs = inputs;
+            this.output = output;
+        }
 
-	}
+        public List<NodeVarValPair> getInputs() {
+            return inputs;
+        }
+
+        public NodeVarValPair getOutput() {
+            return output;
+        }
+    }
 }

--- a/tregression/main/iodetection/IODetector.java
+++ b/tregression/main/iodetection/IODetector.java
@@ -228,6 +228,10 @@ public class IODetector {
             return Objects.equals(node, other.node) && Objects.equals(varVal, other.varVal);
         }
 
+        @Override
+        public String toString() {
+            return "NodeVarValPair [node=" + node + ", varVal=" + varVal + "]";
+        }
     }
 
     public static class IOResult {

--- a/tregression/main/iodetection/IOReader.java
+++ b/tregression/main/iodetection/IOReader.java
@@ -20,7 +20,7 @@ public class IOReader {
             List<IOResult> result = new ArrayList<>();
             String[] splitLine = inputLine.split(IOWriter.IO_DELIMITER);
             for (int i = 0; i < splitLine.length; i += 2) {
-                result.add(new IOResult(splitLine[i], Integer.valueOf(splitLine[i+1])));
+                result.add(new IOResult(splitLine[i], Integer.valueOf(splitLine[i + 1])));
             }
             return Optional.of(result);
         } catch (IOException e) {
@@ -33,7 +33,13 @@ public class IOReader {
         try {
             String[] lines = getLines(path);
             String[] outputStrs = lines[1].split(IOWriter.IO_DELIMITER);
-            return Optional.of(new IOResult(outputStrs[0], Integer.valueOf(outputStrs[1])));
+            int outputStrsLen = outputStrs.length;
+            if (outputStrsLen == 2) {
+                // Wrong Var Value
+                return Optional.of(new IOResult(outputStrs[0], Integer.valueOf(outputStrs[1])));
+            }
+            // Wrong Branch
+            return Optional.of(new IOResult(null, Integer.valueOf(outputStrs[0])));
         } catch (IOException e) {
             e.printStackTrace();
             return Optional.empty();

--- a/tregression/main/iodetection/IOReader.java
+++ b/tregression/main/iodetection/IOReader.java
@@ -3,38 +3,84 @@ package iodetection;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class IOReader {
 
-	public Optional<String[]> readInputs(final Path path) {
-		try {
-			String[] lines = getLines(path);
-			String inputLine = lines[0];
-			if (inputLine.isEmpty()) {
-				return Optional.empty();
-			}
-			return Optional.of(inputLine.split(IOWriter.VAR_VAL_DELIMITER));
-		} catch (IOException e) {
-			e.printStackTrace();
-			return Optional.empty();
-		}
-	}
+    public Optional<List<IOResult>> readInputs(final Path path) {
+        try {
+            String[] lines = getLines(path);
+            String inputLine = lines[0];
+            if (inputLine.isEmpty()) {
+                return Optional.empty();
+            }
+            List<IOResult> result = new ArrayList<>();
+            String[] splitLine = inputLine.split(IOWriter.IO_DELIMITER);
+            for (int i = 0; i < splitLine.length; i += 2) {
+                result.add(new IOResult(splitLine[i], Integer.valueOf(splitLine[i+1])));
+            }
+            return Optional.of(result);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
 
-	public Optional<String> readOutput(final Path path) {
-		try {
-			String[] lines = getLines(path);
-			return Optional.of(lines[1]);
-		} catch (IOException e) {
-			e.printStackTrace();
-			return Optional.empty();
-		} catch (IndexOutOfBoundsException e) {
-			return Optional.empty();
-		}
-	}
+    public Optional<IOResult> readOutput(final Path path) {
+        try {
+            String[] lines = getLines(path);
+            String[] outputStrs = lines[1].split(IOWriter.IO_DELIMITER);
+            return Optional.of(new IOResult(outputStrs[0], Integer.valueOf(outputStrs[1])));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Optional.empty();
+        } catch (IndexOutOfBoundsException e) {
+            return Optional.empty();
+        }
+    }
 
-	private String[] getLines(final Path path) throws IOException {
-		String fileContents = Files.readString(path);
-		return fileContents.split(System.lineSeparator());
-	}
+    private String[] getLines(final Path path) throws IOException {
+        String fileContents = Files.readString(path);
+        return fileContents.split(System.lineSeparator());
+    }
+
+    public static class IOResult {
+        private final String varValStr;
+        private final int nodeOrder;
+
+        public IOResult(String varValStr, int nodeOrder) {
+            super();
+            this.varValStr = varValStr;
+            this.nodeOrder = nodeOrder;
+        }
+
+        public String getVarValStr() {
+            return varValStr;
+        }
+
+        public int getNodeOrder() {
+            return nodeOrder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeOrder, varValStr);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            IOResult other = (IOResult) obj;
+            return nodeOrder == other.nodeOrder && Objects.equals(varValStr, other.varValStr);
+        }
+
+    }
 }

--- a/tregression/main/iodetection/IOWriter.java
+++ b/tregression/main/iodetection/IOWriter.java
@@ -11,37 +11,42 @@ import java.io.IOException;
 import microbat.model.value.VarValue;
 
 public class IOWriter {
-	static final String IO_DELIMITER = " ";
+    static final String IO_DELIMITER = " ";
 
-	public void writeIO(List<NodeVarValPair> inputs, NodeVarValPair output, final Path filePath) throws IOException {
-		String ioStr = formIOStr(inputs, output);
-		Files.write(filePath, ioStr.getBytes());
-	}
+    public void writeIO(List<NodeVarValPair> inputs, NodeVarValPair output, final Path filePath) throws IOException {
+        String ioStr = formIOStr(inputs, output);
+        Files.write(filePath, ioStr.getBytes());
+    }
 
-	private String formVarValueRow(List<NodeVarValPair> nodeVarValPairs) {
-		StringBuilder strBuilder = new StringBuilder();
-		for (NodeVarValPair nodeVarValPair : nodeVarValPairs) {
-		    strBuilder.append(formSingleIOStr(nodeVarValPair));
-	        strBuilder.append(IO_DELIMITER);
-		}
-		int len = strBuilder.length();
-		if (len > 0) {
-			strBuilder.deleteCharAt(len - 1);
-		}
-		return strBuilder.toString();
-	}
+    private String formVarValueRow(List<NodeVarValPair> nodeVarValPairs) {
+        StringBuilder strBuilder = new StringBuilder();
+        for (NodeVarValPair nodeVarValPair : nodeVarValPairs) {
+            strBuilder.append(formSingleIOStr(nodeVarValPair));
+            strBuilder.append(IO_DELIMITER);
+        }
+        int len = strBuilder.length();
+        if (len > 0) {
+            strBuilder.deleteCharAt(len - 1);
+        }
+        return strBuilder.toString();
+    }
 
-	String formIOStr(List<NodeVarValPair> inputs, NodeVarValPair output) {
-		String inputRow = formVarValueRow(inputs);
-		return String.join(System.lineSeparator(), inputRow, formSingleIOStr(output)) + System.lineSeparator();
-	}
-	
-	private StringBuilder formSingleIOStr(NodeVarValPair nodeVarValPair) {
-	    StringBuilder strBuilder = new StringBuilder();
-        if (nodeVarValPair == null) return strBuilder;
-        strBuilder.append(nodeVarValPair.getVarVal().getVarID());
-        strBuilder.append(IO_DELIMITER);
+    String formIOStr(List<NodeVarValPair> inputs, NodeVarValPair output) {
+        String inputRow = formVarValueRow(inputs);
+        return String.join(System.lineSeparator(), inputRow, formSingleIOStr(output)) + System.lineSeparator();
+    }
+
+    private StringBuilder formSingleIOStr(NodeVarValPair nodeVarValPair) {
+        StringBuilder strBuilder = new StringBuilder();
+        if (nodeVarValPair == null) {
+            return strBuilder;
+        }
+        VarValue wrongVarValue = nodeVarValPair.getVarVal();
+        if (wrongVarValue != null) {
+            strBuilder.append(wrongVarValue.getVarID());
+            strBuilder.append(IO_DELIMITER);
+        }
         strBuilder.append(nodeVarValPair.getNode().getOrder());
         return strBuilder;
-	}
+    }
 }

--- a/tregression/main/iodetection/IOWriter.java
+++ b/tregression/main/iodetection/IOWriter.java
@@ -4,23 +4,25 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import iodetection.IODetector.NodeVarValPair;
+
 import java.io.IOException;
 
 import microbat.model.value.VarValue;
 
 public class IOWriter {
-	static final String VAR_VAL_DELIMITER = " ";
+	static final String IO_DELIMITER = " ";
 
-	public void writeIO(List<VarValue> inputs, VarValue output, final Path filePath) throws IOException {
-		String ioStr = formIOStr(inputs, output, filePath);
+	public void writeIO(List<NodeVarValPair> inputs, NodeVarValPair output, final Path filePath) throws IOException {
+		String ioStr = formIOStr(inputs, output);
 		Files.write(filePath, ioStr.getBytes());
 	}
 
-	private String formVarValueRow(List<VarValue> varValues) {
+	private String formVarValueRow(List<NodeVarValPair> nodeVarValPairs) {
 		StringBuilder strBuilder = new StringBuilder();
-		for (VarValue varValue : varValues) {
-			strBuilder.append(varValue.getVarID());
-			strBuilder.append(VAR_VAL_DELIMITER);
+		for (NodeVarValPair nodeVarValPair : nodeVarValPairs) {
+		    strBuilder.append(formSingleIOStr(nodeVarValPair));
+	        strBuilder.append(IO_DELIMITER);
 		}
 		int len = strBuilder.length();
 		if (len > 0) {
@@ -29,8 +31,17 @@ public class IOWriter {
 		return strBuilder.toString();
 	}
 
-	String formIOStr(List<VarValue> inputs, VarValue output, final Path filePath) {
+	String formIOStr(List<NodeVarValPair> inputs, NodeVarValPair output) {
 		String inputRow = formVarValueRow(inputs);
-		return String.join(System.lineSeparator(), inputRow, output.getVarID()) + System.lineSeparator();
+		return String.join(System.lineSeparator(), inputRow, formSingleIOStr(output)) + System.lineSeparator();
+	}
+	
+	private StringBuilder formSingleIOStr(NodeVarValPair nodeVarValPair) {
+	    StringBuilder strBuilder = new StringBuilder();
+        if (nodeVarValPair == null) return strBuilder;
+        strBuilder.append(nodeVarValPair.getVarVal().getVarID());
+        strBuilder.append(IO_DELIMITER);
+        strBuilder.append(nodeVarValPair.getNode().getOrder());
+        return strBuilder;
 	}
 }

--- a/tregression/main/tregression/auto/MutationRunner.java
+++ b/tregression/main/tregression/auto/MutationRunner.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import iodetection.IODetector;
 import iodetection.IOWriter;
 import iodetection.IODetector.IOResult;
+import iodetection.IODetector.NodeVarValPair;
 import jmutation.dataset.BugDataset;
 import jmutation.dataset.bug.minimize.ProjectMinimizer;
 import jmutation.dataset.bug.model.path.MutationFrameworkPathConfiguration;
@@ -182,10 +183,10 @@ public class MutationRunner extends ProjectsRunner {
 	}
 	
 	private void printIOResult(IOResult io) {
-		List<VarValue> inputs = io.getInputs();
-		VarValue output = io.getOutput();
+		List<NodeVarValPair> inputs = io.getInputs();
+		NodeVarValPair output = io.getOutput();
 		System.out.println(String.join(" ", LINE, "inputs", LINE));
-		for (VarValue input : inputs) {
+		for (NodeVarValPair input : inputs) {
 			System.out.println(input);
 		}
 		System.out.println(String.join(" ", LINE, "output", LINE));

--- a/tregression/main/tregression/handler/MutationRunnerHandler.java
+++ b/tregression/main/tregression/handler/MutationRunnerHandler.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.preference.PreferenceStore;
 
 import iodetection.IODetector;
 import iodetection.IODetector.IOResult;
+import iodetection.IODetector.NodeVarValPair;
 import iodetection.IOWriter;
 import jmutation.dataset.BugDataset;
 import jmutation.dataset.bug.minimize.ProjectMinimizer;
@@ -340,10 +341,10 @@ public class MutationRunnerHandler extends AbstractHandler {
 	}
 
 	private void printIOResult(IOResult io) {
-		List<VarValue> inputs = io.getInputs();
-		VarValue output = io.getOutput();
+		List<NodeVarValPair> inputs = io.getInputs();
+		NodeVarValPair output = io.getOutput();
 		System.out.println(String.join(" ", LINE, "inputs", LINE));
-		for (VarValue input : inputs) {
+		for (NodeVarValPair input : inputs) {
 			System.out.println(input);
 		}
 		System.out.println(String.join(" ", LINE, "output", LINE));

--- a/tregression/test-dir/test/iodetection/IODetectorIT.java
+++ b/tregression/test-dir/test/iodetection/IODetectorIT.java
@@ -216,8 +216,8 @@ class IODetectorIT {
 				IODetector detector = testObjects.getIoDetector();
 				Trace buggyTrace = testObjects.getBuggyTrace();
 				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(6);
-				VarValue expectedVarVal = expectedOutputNode.getWrittenVariables().get(0);
+				TraceNode expectedOutputNode = buggyTrace.getTraceNode(7);
+				VarValue expectedVarVal = null;
 				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
 				assertEquals(expectedVarVal, output.getVarVal());
 			}
@@ -252,8 +252,8 @@ class IODetectorIT {
 				IODetector detector = testObjects.getIoDetector();
 				Trace buggyTrace = testObjects.getBuggyTrace();
 				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(14);
-				VarValue expectedVarVal = expectedOutputNode.getWrittenVariables().get(0);
+				TraceNode expectedOutputNode = buggyTrace.getTraceNode(15);
+				VarValue expectedVarVal = null;
 				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
 				assertEquals(expectedVarVal, output.getVarVal());
 			}

--- a/tregression/test-dir/test/iodetection/IODetectorIT.java
+++ b/tregression/test-dir/test/iodetection/IODetectorIT.java
@@ -54,539 +54,554 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class IODetectorIT {
 
-	private static final Path TEST_FILES_DIR = Paths.get("test-dir", "files", "iodetection");
-	private static final String SAMPLE_PROJECT_FORMAT = "projects\\%d";
-	private static final String SRC_DIR = "src\\main\\java";
-	private static final String TEST_DIR = "src\\test\\java";
-	private static final String BUGGY_TRACE_FMT = "buggy-%s-trace.exec";
-	private static final String WORKING_TRACE_FMT = "working-%s-trace.exec";
+    private static final Path TEST_FILES_DIR = Paths.get("test-dir", "files", "iodetection");
+    private static final String SAMPLE_PROJECT_FORMAT = "projects\\%d";
+    private static final String SRC_DIR = "src\\main\\java";
+    private static final String TEST_DIR = "src\\test\\java";
+    private static final String BUGGY_TRACE_FMT = "buggy-%s-trace.exec";
+    private static final String WORKING_TRACE_FMT = "working-%s-trace.exec";
 
-	private Map<String, CompilationUnit> pathToCompilationUnitMap;
+    private Map<String, CompilationUnit> pathToCompilationUnitMap;
 
-	@BeforeEach
-	void setUp() {
-		pathToCompilationUnitMap = new HashMap<>();
-	}
+    @BeforeEach
+    void setUp() {
+        pathToCompilationUnitMap = new HashMap<>();
+    }
 
-	@Test
-	void detect_InputNotReadOnlyWritten_ObtainsIO() {
-		IODetectorTestObjects testObjects = constructTestObjects("input-written-only", 5);
-		IODetector detector = testObjects.getIoDetector();
-		Trace buggyTrace = testObjects.getBuggyTrace();
-		IOResult result = detector.detect().get();
-		TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-		expectedOutputNode.getReadVariables().get(0);
-		VarValue expectedOutput = expectedOutputNode.getReadVariables().get(0);
+    @Test
+    void detect_InputNotReadOnlyWritten_ObtainsIO() {
+        IODetectorTestObjects testObjects = constructTestObjects("input-written-only", 5);
+        IODetector detector = testObjects.getIoDetector();
+        Trace buggyTrace = testObjects.getBuggyTrace();
+        IOResult result = detector.detect().get();
+        TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+        expectedOutputNode.getReadVariables().get(0);
+        VarValue expectedOutput = expectedOutputNode.getReadVariables().get(0);
         assertEquals(expectedOutputNode, result.getOutput().getNode());
-		assertEquals(expectedOutput, result.getOutput().getVarVal());
+        assertEquals(expectedOutput, result.getOutput().getVarVal());
 
-		Set<NodeVarValPair> expectedInputs = new HashSet<>();
-		expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
-		expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
-		expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
-		expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(6), false));
-		assertEquals(expectedInputs, new HashSet<>(result.getInputs()));
-	}
+        Set<NodeVarValPair> expectedInputs = new HashSet<>();
+        expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+        expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
+        expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
+        expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(6), false));
+        assertEquals(expectedInputs, new HashSet<>(result.getInputs()));
+    }
 
-	@Nested
-	class ObtainingInputs {
+    @Nested
+    class ObtainingInputs {
 
-		@Test
-		void detectInputVarValsFromOutput_InputNotReadOnlyWritten_ObtainsInputs() {
-			IODetectorTestObjects testObjects = constructTestObjects("input-written-only", 5);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			TraceNode outputNode = buggyTrace.getLatestNode();
-			outputNode.getReadVariables().get(0);
-			VarValue output = outputNode.getReadVariables().get(0);
-			List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-			Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			TraceNode node1 = buggyTrace.getTraceNode(1);
-			node1.getReadVariables().forEach(varVal -> expectedInputs.add(new NodeVarValPair(node1, varVal)));
+        @Test
+        void detectInputVarValsFromOutput_InputNotReadOnlyWritten_ObtainsInputs() {
+            IODetectorTestObjects testObjects = constructTestObjects("input-written-only", 5);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getLatestNode();
+            outputNode.getReadVariables().get(0);
+            VarValue output = outputNode.getReadVariables().get(0);
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            TraceNode node1 = buggyTrace.getTraceNode(1);
+            node1.getReadVariables().forEach(varVal -> expectedInputs.add(new NodeVarValPair(node1, varVal)));
             expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
             expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
             expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
             expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(6), false));
-			assertEquals(expectedInputs, new HashSet<>(inputs));
-		}
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
 
-		@Test
-		void detectInputVarValsFromOutput_ArrayInputs_ObtainsInputs() {
-			IODetectorTestObjects testObjects = constructTestObjects("array-input", 6);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			TraceNode outputNode = buggyTrace.getLatestNode();
-			outputNode.getReadVariables().get(0);
-			VarValue output = outputNode.getReadVariables().get(0);
-			List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-			Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(2), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(6), false));
-			assertEquals(expectedInputs, new HashSet<>(inputs));
-		}
+        @Test
+        void detectInputVarValsFromOutput_ArrayInputs_ObtainsInputs() {
+            IODetectorTestObjects testObjects = constructTestObjects("array-input", 6);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getLatestNode();
+            outputNode.getReadVariables().get(0);
+            VarValue output = outputNode.getReadVariables().get(0);
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(2), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(6), false));
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
 
-		@Test
-		void detectInputVarValsFromOutput_WrongIntermediateValue_DoesNotIncludeWrongValueAsInput() {
-			IODetectorTestObjects testObjects = constructTestObjects("wrong-intermediate-value", 7);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			TraceNode outputNode = buggyTrace.getLatestNode();
-			outputNode.getReadVariables().get(0);
-			VarValue output = outputNode.getReadVariables().get(0);
-			List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-			Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
-			TraceNode node8 = buggyTrace.getTraceNode(8);
-			expectedInputs.add(new NodeVarValPair(node8, node8.getWrittenVariables().get(0)));
-			assertEquals(expectedInputs, new HashSet<>(inputs));
-		}
+        @Test
+        void detectInputVarValsFromOutput_WrongIntermediateValue_DoesNotIncludeWrongValueAsInput() {
+            IODetectorTestObjects testObjects = constructTestObjects("wrong-intermediate-value", 7);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getLatestNode();
+            outputNode.getReadVariables().get(0);
+            VarValue output = outputNode.getReadVariables().get(0);
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
+            TraceNode node8 = buggyTrace.getTraceNode(8);
+            expectedInputs.add(new NodeVarValPair(node8, node8.getWrittenVariables().get(0)));
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
 
-		@Test
-		void detectInputVarValsFromOutput_InputFromAnotherTestClass_ObtainsInputs() {
-			IODetectorTestObjects testObjects = constructTestObjects("input-from-another-class", 8);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			TraceNode outputNode = buggyTrace.getLatestNode();
-			outputNode.getReadVariables().get(0);
-			VarValue output = outputNode.getReadVariables().get(0);
-			List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-			Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(8), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(9), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(11), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(12), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(13), false));
-			assertEquals(expectedInputs, new HashSet<>(inputs));
-		}
+        @Test
+        void detectInputVarValsFromOutput_InputFromAnotherTestClass_ObtainsInputs() {
+            IODetectorTestObjects testObjects = constructTestObjects("input-from-another-class", 8);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getLatestNode();
+            outputNode.getReadVariables().get(0);
+            VarValue output = outputNode.getReadVariables().get(0);
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(8), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(9), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(11), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(12), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(13), false));
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
 
-		@Test
-		void detectInputVarValsFromOutput_OutputHasNoDataDependencies_ObtainsInputs() {
-			IODetectorTestObjects testObjects = constructTestObjects("null-ptr-exception", 2);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			TraceNode outputNode = buggyTrace.getLatestNode();
-			VarValue output = outputNode.getReadVariables().get(0);
-			List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-			Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
-			expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
-			assertEquals(expectedInputs, new HashSet<>(inputs));
-		}
-	}
+        @Test
+        void detectInputVarValsFromOutput_OutputHasNoDataDependencies_ObtainsInputs() {
+            IODetectorTestObjects testObjects = constructTestObjects("null-ptr-exception", 2);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getLatestNode();
+            VarValue output = outputNode.getReadVariables().get(0);
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
 
-	@Nested
-	class ObtainingOutputs {
+        @Test
+        void detectOutput_ExceptionThrownResultingInWrongBranch_ObtainsInputs() {
+            IODetectorTestObjects testObjects = constructTestObjects("regular-exception", 1);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            TraceNode outputNode = buggyTrace.getTraceNode(7);
+            VarValue output = null;
+            List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+            Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(1), true));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(4), false));
+            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(buggyTrace.getTraceNode(5), false));
+            assertEquals(expectedInputs, new HashSet<>(inputs));
+        }
+    }
 
-		@Test
-		void detectOutput_WrongIntermediateValue_OnlyTakesWrongValueFromLatestNode() {
-			IODetectorTestObjects testObjects = constructTestObjects("wrong-intermediate-value", 7);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			NodeVarValPair output = detector.detectOutput().get();
-			TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-			VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-			assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-			assertEquals(expectedVarVal, output.getVarVal());
-		}
+    @Nested
+    class ObtainingOutputs {
 
-		@Test
-		void detectOutput_WrongArrayContents_TakesTheAccessedContent() {
-			IODetectorTestObjects testObjects = constructTestObjects("array-contents-diff", 10);
-			IODetector detector = testObjects.getIoDetector();
-			Trace buggyTrace = testObjects.getBuggyTrace();
-			NodeVarValPair output = detector.detectOutput().get();
-			TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-			VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-			assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-			assertEquals(expectedVarVal, output.getVarVal());
-		}
+        @Test
+        void detectOutput_WrongIntermediateValue_OnlyTakesWrongValueFromLatestNode() {
+            IODetectorTestObjects testObjects = constructTestObjects("wrong-intermediate-value", 7);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            NodeVarValPair output = detector.detectOutput().get();
+            TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+            VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+            assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+            assertEquals(expectedVarVal, output.getVarVal());
+        }
 
-		@Nested
-		class ObtainingOutputsAfterException {
-			@Test
-			void detectOutput_ExceptionThrown_ObtainsControlDominatorAsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjects("regular-exception", 1);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(7);
-				VarValue expectedVarVal = null;
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+        @Test
+        void detectOutput_WrongArrayContents_TakesTheAccessedContent() {
+            IODetectorTestObjects testObjects = constructTestObjects("array-contents-diff", 10);
+            IODetector detector = testObjects.getIoDetector();
+            Trace buggyTrace = testObjects.getBuggyTrace();
+            NodeVarValPair output = detector.detectOutput().get();
+            TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+            VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+            assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+            assertEquals(expectedVarVal, output.getVarVal());
+        }
 
-			@Test
-			void detectOutput_NullPointerExceptionThrown_ObtainsNullAsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjects("null-ptr-exception", 2);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+        @Nested
+        class ObtainingOutputsAfterException {
+            @Test
+            void detectOutput_ExceptionThrown_ObtainsControlDominatorAsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjects("regular-exception", 1);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getTraceNode(7);
+                VarValue expectedVarVal = null;
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			@Test
-			void detectOutput_DivByZeroExceptionThrown_ObtainsZeroAsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjects("div-by-zero-exception", 3);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+            @Test
+            void detectOutput_NullPointerExceptionThrown_ObtainsNullAsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjects("null-ptr-exception", 2);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			@Test
-			void detectOutput_OutOfBoundsExceptionThrown_ObtainsAccessingIndexAsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjects("out-of-bounds-exception", 4);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(15);
-				VarValue expectedVarVal = null;
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+            @Test
+            void detectOutput_DivByZeroExceptionThrown_ObtainsZeroAsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjects("div-by-zero-exception", 3);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			@Test
-			void detectOutput_OutOfBoundsExceptionThrownDueToDataStructureSize_ObtainsDataStructureSizeAsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjects("out-of-bounds-list-size", 9);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(10);
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0).getChildren().get(1);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
-		}
-	}
+            @Test
+            void detectOutput_OutOfBoundsExceptionThrown_ObtainsAccessingIndexAsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjects("out-of-bounds-exception", 4);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getTraceNode(15);
+                VarValue expectedVarVal = null;
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-	/**
-	 * Requires unzipping the math_70 dataset on server 250, which may interfere
-	 * with anyone else using it.
-	 * 
-	 * @author Chenghin
-	 *
-	 */
-	@Disabled
-	@Nested
-	class Math70 {
-		private static final String DATA_SET_BUG_DIR_FORMAT = "E:\\david\\Mutation_Dataset\\math_70\\%d\\bug";
-		private static final String DATA_SET_FIX_DIR = "E:\\david\\Mutation_Dataset\\math_70\\fix";
+            @Test
+            void detectOutput_OutOfBoundsExceptionThrownDueToDataStructureSize_ObtainsDataStructureSizeAsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjects("out-of-bounds-list-size", 9);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getTraceNode(10);
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0).getChildren().get(1);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
+        }
+    }
 
-		@Nested
-		class ObtainingInputs {
-			// math_70 bug ID 1
-			@Test
-			void detectInputVarValsFromOutput_AnonymousInputs_ObtainsInputs() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("SingleAssertionAndAllInputsInTest", 1);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				TraceNode outputNode = buggyTrace.getLatestNode();
-				outputNode.getReadVariables().get(0);
-				VarValue output = outputNode.getReadVariables().get(0);
-				List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-				Set<NodeVarValPair> expectedInputs = new HashSet<>();
-				TraceNode node1 = buggyTrace.getTraceNode(1);
-	            expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(node1, false));
-				expectedInputs.add(new NodeVarValPair(node1, node1.getReadVariables().get(0)));
-				assertEquals(expectedInputs, new HashSet<>(inputs));
-			}
+    /**
+     * Requires unzipping the math_70 dataset on server 250, which may interfere
+     * with anyone else using it.
+     * 
+     * @author Chenghin
+     *
+     */
+    @Disabled
+    @Nested
+    class Math70 {
+        private static final String DATA_SET_BUG_DIR_FORMAT = "E:\\david\\Mutation_Dataset\\math_70\\%d\\bug";
+        private static final String DATA_SET_FIX_DIR = "E:\\david\\Mutation_Dataset\\math_70\\fix";
 
-			// math_70 bug ID 2
-			// x at line 86, Math.cosh, sinh, tanh, log, ceil
-			// Current inputs:
-			// CBRT, COSH, EXPM1, TANH, ABS, this, x, conditional result of loop, SQRT, SINH
-			// Does not have log, ceil (both used "postCompose", e.g. log.postCompose, while
-			// others used "of"), and has additional cbrt.
-			// Sometimes, the VarValues' children can form links as well.
-			// After fixing bug: sqrt, log, tanh, sinh, abs, ceil, expm1, cosh, cbrt, 0.1,
-			// conditional result
-			@Test
-			void detectInputVarValsFromOutput_MultiplePossibleInputs_ObtainsOnlyImportantInputs() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70(
-						"MultipleAssertionsMultiLineAssertionWithEpsilon", 2);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				TraceNode outputNode = buggyTrace.getTraceNode(1537);
-				outputNode.getReadVariables().get(0);
-				VarValue output = outputNode.getReadVariables().get(0);
-				List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-				Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			}
+        @Nested
+        class ObtainingInputs {
+            // math_70 bug ID 1
+            @Test
+            void detectInputVarValsFromOutput_AnonymousInputs_ObtainsInputs() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("SingleAssertionAndAllInputsInTest", 1);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                TraceNode outputNode = buggyTrace.getLatestNode();
+                outputNode.getReadVariables().get(0);
+                VarValue output = outputNode.getReadVariables().get(0);
+                List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+                Set<NodeVarValPair> expectedInputs = new HashSet<>();
+                TraceNode node1 = buggyTrace.getTraceNode(1);
+                expectedInputs.addAll(createNodeVarValPairsFromNodeAndVarVals(node1, false));
+                expectedInputs.add(new NodeVarValPair(node1, node1.getReadVariables().get(0)));
+                assertEquals(expectedInputs, new HashSet<>(inputs));
+            }
 
-			// math_70 bug ID 3
-			// expected ComposableFunction.COS, 3, x
-			// After modifying to use getInvocationMethodOrControlDominator:
-			// We have COS, 0.1/x at line 357, 3/a, SIN, this at line 23, conditional result
-			// in for loop, 5/scaleFactor in line 398
-			// - Why did we get sin? Anonymous class data domination is not accurate. It
-			// will point to the previous same anonymous class initialization
-			// node 45, this$0 -> node 38 (another anonymous ComposableFunction init)
-			@Test
-			void detectInputVarValsFromOutput_MultiplePossibleInputs_ObtainsOnlyImportantInputs1() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-3", 3);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				TraceNode outputNode = buggyTrace.getLatestNode();
-				outputNode.getReadVariables().get(0);
-				VarValue output = outputNode.getReadVariables().get(0);
-				List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-				Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			}
+            // math_70 bug ID 2
+            // x at line 86, Math.cosh, sinh, tanh, log, ceil
+            // Current inputs:
+            // CBRT, COSH, EXPM1, TANH, ABS, this, x, conditional result of loop, SQRT, SINH
+            // Does not have log, ceil (both used "postCompose", e.g. log.postCompose, while
+            // others used "of"), and has additional cbrt.
+            // Sometimes, the VarValues' children can form links as well.
+            // After fixing bug: sqrt, log, tanh, sinh, abs, ceil, expm1, cosh, cbrt, 0.1,
+            // conditional result
+            @Test
+            void detectInputVarValsFromOutput_MultiplePossibleInputs_ObtainsOnlyImportantInputs() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70(
+                        "MultipleAssertionsMultiLineAssertionWithEpsilon", 2);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                TraceNode outputNode = buggyTrace.getTraceNode(1537);
+                outputNode.getReadVariables().get(0);
+                VarValue output = outputNode.getReadVariables().get(0);
+                List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+                Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            }
 
-			// math_70 bug ID 5
-			// Expected .2, .2, .5, a, b, c
-			// Current obtained inputs:
-			// We now have .2, .2, .5, a, b, c, drk, Double array.
-			// Questions:
-			// 1. Why do we have Double array, but not String array?
-			// Ans: String array is passed into Arrays.asList, which is excluded from
-			// instrumentation.
-			// 2. Why do we have drk & its original input? (Should only be original input)
-			// Ans: When initialization for drk is done, it is only written to drk. The
-			// constructor return value is not read.
-			@Test
-			void detectInputVarValsFromOutput_ArrayInputs_ObtainsInputs() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("ArrayInput", 5);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				TraceNode outputNode = buggyTrace.getLatestNode();
-				outputNode.getReadVariables().get(0);
-				VarValue output = outputNode.getReadVariables().get(0);
-				List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
-				Set<NodeVarValPair> expectedInputs = new HashSet<>();
-			}
-		}
+            // math_70 bug ID 3
+            // expected ComposableFunction.COS, 3, x
+            // After modifying to use getInvocationMethodOrControlDominator:
+            // We have COS, 0.1/x at line 357, 3/a, SIN, this at line 23, conditional result
+            // in for loop, 5/scaleFactor in line 398
+            // - Why did we get sin? Anonymous class data domination is not accurate. It
+            // will point to the previous same anonymous class initialization
+            // node 45, this$0 -> node 38 (another anonymous ComposableFunction init)
+            @Test
+            void detectInputVarValsFromOutput_MultiplePossibleInputs_ObtainsOnlyImportantInputs1() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-3", 3);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                TraceNode outputNode = buggyTrace.getLatestNode();
+                outputNode.getReadVariables().get(0);
+                VarValue output = outputNode.getReadVariables().get(0);
+                List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+                Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            }
 
-		@Nested
-		class ObtainingOutput {
-			// math_70 bug ID 1
-			@Test
-			void detectOutput_LastNodeAssertionSingleReadVar_ObtainsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("SingleAssertionAndAllInputsInTest", 1);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				assertEquals(3, output.getNode().getOrder());
-				TraceNode outputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = outputNode.getReadVariables().get(0);
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+            // math_70 bug ID 5
+            // Expected .2, .2, .5, a, b, c
+            // Current obtained inputs:
+            // We now have .2, .2, .5, a, b, c, drk, Double array.
+            // Questions:
+            // 1. Why do we have Double array, but not String array?
+            // Ans: String array is passed into Arrays.asList, which is excluded from
+            // instrumentation.
+            // 2. Why do we have drk & its original input? (Should only be original input)
+            // Ans: When initialization for drk is done, it is only written to drk. The
+            // constructor return value is not read.
+            @Test
+            void detectInputVarValsFromOutput_ArrayInputs_ObtainsInputs() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("ArrayInput", 5);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                TraceNode outputNode = buggyTrace.getLatestNode();
+                outputNode.getReadVariables().get(0);
+                VarValue output = outputNode.getReadVariables().get(0);
+                List<NodeVarValPair> inputs = detector.detectInputVarValsFromOutput(outputNode, output);
+                Set<NodeVarValPair> expectedInputs = new HashSet<>();
+            }
+        }
 
-			// math_70 bug ID 2
-			@Test
-			void detectOutput_MultiLineAssertionWithEpsilon_ObtainsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70(
-						"MultipleAssertionsMultiLineAssertionWithEpsilon", 2);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				assertEquals(1537, output.getNode().getOrder());
-				TraceNode expectedOutputNode = buggyTrace.getTraceNode(1537);
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+        @Nested
+        class ObtainingOutput {
+            // math_70 bug ID 1
+            @Test
+            void detectOutput_LastNodeAssertionSingleReadVar_ObtainsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("SingleAssertionAndAllInputsInTest", 1);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                assertEquals(3, output.getNode().getOrder());
+                TraceNode outputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = outputNode.getReadVariables().get(0);
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			// math_70 bug ID 3
-			@Test
-			void detectOutput_LastNodeAssertion_ObtainsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-3", 3);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+            // math_70 bug ID 2
+            @Test
+            void detectOutput_MultiLineAssertionWithEpsilon_ObtainsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70(
+                        "MultipleAssertionsMultiLineAssertionWithEpsilon", 2);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                assertEquals(1537, output.getNode().getOrder());
+                TraceNode expectedOutputNode = buggyTrace.getTraceNode(1537);
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			// math_70 bug ID 5
-			@Test
-			void detectOutput_ArrayInputs_ObtainsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("ArrayInput", 5);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
+            // math_70 bug ID 3
+            @Test
+            void detectOutput_LastNodeAssertion_ObtainsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-3", 3);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-			// math_70 bug ID 8
-			@Test
-			void detectOutput_Test_ObtainsOutput() {
-				IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-8", 8);
-				IODetector detector = testObjects.getIoDetector();
-				Trace buggyTrace = testObjects.getBuggyTrace();
-				NodeVarValPair output = detector.detectOutput().get();
-				TraceNode expectedOutputNode = buggyTrace.getLatestNode();
-				VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
-				assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
-				assertEquals(expectedVarVal, output.getVarVal());
-			}
-		}
+            // math_70 bug ID 5
+            @Test
+            void detectOutput_ArrayInputs_ObtainsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("ArrayInput", 5);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
 
-		private IODetectorTestObjects constructTestObjectsMath70(String traceName, int projectID) {
-			String buggyPath = String.format(DATA_SET_BUG_DIR_FORMAT, projectID);
-			return constructTestObjects(traceName, buggyPath, DATA_SET_FIX_DIR);
-		}
+            // math_70 bug ID 8
+            @Test
+            void detectOutput_Test_ObtainsOutput() {
+                IODetectorTestObjects testObjects = constructTestObjectsMath70("math_70-8", 8);
+                IODetector detector = testObjects.getIoDetector();
+                Trace buggyTrace = testObjects.getBuggyTrace();
+                NodeVarValPair output = detector.detectOutput().get();
+                TraceNode expectedOutputNode = buggyTrace.getLatestNode();
+                VarValue expectedVarVal = expectedOutputNode.getReadVariables().get(0);
+                assertEquals(expectedOutputNode.getOrder(), output.getNode().getOrder());
+                assertEquals(expectedVarVal, output.getVarVal());
+            }
+        }
 
-	}
+        private IODetectorTestObjects constructTestObjectsMath70(String traceName, int projectID) {
+            String buggyPath = String.format(DATA_SET_BUG_DIR_FORMAT, projectID);
+            return constructTestObjects(traceName, buggyPath, DATA_SET_FIX_DIR);
+        }
 
-	private static class IODetectorTestObjects {
-		private final Trace buggyTrace;
-		private final IODetector ioDetector;
+    }
 
-		public IODetectorTestObjects(Trace buggyTrace, IODetector ioDetector) {
-			super();
-			this.buggyTrace = buggyTrace;
-			this.ioDetector = ioDetector;
-		}
+    private static class IODetectorTestObjects {
+        private final Trace buggyTrace;
+        private final IODetector ioDetector;
 
-		public Trace getBuggyTrace() {
-			return buggyTrace;
-		}
+        public IODetectorTestObjects(Trace buggyTrace, IODetector ioDetector) {
+            super();
+            this.buggyTrace = buggyTrace;
+            this.ioDetector = ioDetector;
+        }
 
-		public IODetector getIoDetector() {
-			return ioDetector;
-		}
+        public Trace getBuggyTrace() {
+            return buggyTrace;
+        }
 
-	}
+        public IODetector getIoDetector() {
+            return ioDetector;
+        }
 
-	private IODetectorTestObjects constructTestObjects(String traceName, int projectID) {
-		String projectRoot = TEST_FILES_DIR.resolve(String.format(SAMPLE_PROJECT_FORMAT, projectID)).toAbsolutePath()
-				.toString();
-		String buggyPath = projectRoot + "\\bug";
-		String workingPath = projectRoot + "\\fix";
-		return constructTestObjects(traceName, buggyPath, workingPath);
-	}
+    }
 
-	private IODetectorTestObjects constructTestObjects(String traceName, String buggyPath, String workingPath) {
-		Trace buggyTrace = RunningInfo
-				.readFromFile(TEST_FILES_DIR.resolve(String.format(BUGGY_TRACE_FMT, traceName)).toFile())
-				.getMainTrace();
-		Trace workingTrace = RunningInfo
-				.readFromFile(TEST_FILES_DIR.resolve(String.format(WORKING_TRACE_FMT, traceName)).toFile())
-				.getMainTrace();
-		appendMissingInfoToExecutionList(buggyTrace.getExecutionList(), buggyPath);
-		appendMissingInfoToExecutionList(workingTrace.getExecutionList(), workingPath);
-		return new IODetectorTestObjects(buggyTrace, constructIODetector(buggyTrace, workingTrace,
-				createPairList(buggyTrace, workingTrace, buggyPath, workingPath)));
-	}
+    private IODetectorTestObjects constructTestObjects(String traceName, int projectID) {
+        String projectRoot = TEST_FILES_DIR.resolve(String.format(SAMPLE_PROJECT_FORMAT, projectID)).toAbsolutePath()
+                .toString();
+        String buggyPath = projectRoot + "\\bug";
+        String workingPath = projectRoot + "\\fix";
+        return constructTestObjects(traceName, buggyPath, workingPath);
+    }
 
-	private IODetector constructIODetector(Trace buggyTrace, Trace workingTrace, PairList pairList) {
-		return new IODetector(buggyTrace, TEST_DIR, pairList);
-	}
+    private IODetectorTestObjects constructTestObjects(String traceName, String buggyPath, String workingPath) {
+        Trace buggyTrace = RunningInfo
+                .readFromFile(TEST_FILES_DIR.resolve(String.format(BUGGY_TRACE_FMT, traceName)).toFile())
+                .getMainTrace();
+        Trace workingTrace = RunningInfo
+                .readFromFile(TEST_FILES_DIR.resolve(String.format(WORKING_TRACE_FMT, traceName)).toFile())
+                .getMainTrace();
+        appendMissingInfoToExecutionList(buggyTrace.getExecutionList(), buggyPath);
+        appendMissingInfoToExecutionList(workingTrace.getExecutionList(), workingPath);
+        return new IODetectorTestObjects(buggyTrace, constructIODetector(buggyTrace, workingTrace,
+                createPairList(buggyTrace, workingTrace, buggyPath, workingPath)));
+    }
 
-	private void appendMissingInfoToExecutionList(List<TraceNode> executionList, String path) {
-		setJavaPathToBreakPoints(executionList, path);
-		setMissingReadVariables(executionList);
-	}
+    private IODetector constructIODetector(Trace buggyTrace, Trace workingTrace, PairList pairList) {
+        return new IODetector(buggyTrace, TEST_DIR, pairList);
+    }
 
-	private void setJavaPathToBreakPoints(List<TraceNode> executionList, String path) {
-		for (int i = 0; i < executionList.size(); i++) {
-			TraceNode node = executionList.get(i);
-			BreakPoint breakPoint = node.getBreakPoint();
-			String className = breakPoint.getClassCanonicalName();
-			if (className.contains("$")) {
-				className = className.substring(0, className.indexOf("$"));
-			}
-			String classPath = className.replace(".", File.separator) + ".java";
-			String testPath = String.join(File.separator, path, TEST_DIR, classPath);
-			if (new File(testPath).exists()) {
-				breakPoint.setFullJavaFilePath(testPath);
-			} else {
-				breakPoint.setFullJavaFilePath(String.join(File.separator, path, SRC_DIR, classPath));
-			}
-		}
-	}
+    private void appendMissingInfoToExecutionList(List<TraceNode> executionList, String path) {
+        setJavaPathToBreakPoints(executionList, path);
+        setMissingReadVariables(executionList);
+    }
 
-	private void setMissingReadVariables(List<TraceNode> executionList) {
-		for (TraceNode node : executionList) {
-			if (!node.getInvocationChildren().isEmpty() && node.getReadVariables().isEmpty()) {
-				// check AST completeness
-				CompilationUnit cu;
-				try {
-					cu = getCompilationUnit(Paths.get(node.getBreakPoint().getFullJavaFilePath()));
-				} catch (IOException e) {
-					e.printStackTrace();
-					continue;
-				}
-				MinimumASTNodeFinder finder = new MinimumASTNodeFinder(node.getLineNumber(), cu);
-				cu.accept(finder);
-				ASTNode astNode = finder.getMinimumNode();
+    private void setJavaPathToBreakPoints(List<TraceNode> executionList, String path) {
+        for (int i = 0; i < executionList.size(); i++) {
+            TraceNode node = executionList.get(i);
+            BreakPoint breakPoint = node.getBreakPoint();
+            String className = breakPoint.getClassCanonicalName();
+            if (className.contains("$")) {
+                className = className.substring(0, className.indexOf("$"));
+            }
+            String classPath = className.replace(".", File.separator) + ".java";
+            String testPath = String.join(File.separator, path, TEST_DIR, classPath);
+            if (new File(testPath).exists()) {
+                breakPoint.setFullJavaFilePath(testPath);
+            } else {
+                breakPoint.setFullJavaFilePath(String.join(File.separator, path, SRC_DIR, classPath));
+            }
+        }
+    }
 
-				if (astNode != null) {
-					int start = cu.getLineNumber(astNode.getStartPosition());
-					int end = cu.getLineNumber(astNode.getStartPosition() + astNode.getLength());
+    private void setMissingReadVariables(List<TraceNode> executionList) {
+        for (TraceNode node : executionList) {
+            if (!node.getInvocationChildren().isEmpty() && node.getReadVariables().isEmpty()) {
+                // check AST completeness
+                CompilationUnit cu;
+                try {
+                    cu = getCompilationUnit(Paths.get(node.getBreakPoint().getFullJavaFilePath()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    continue;
+                }
+                MinimumASTNodeFinder finder = new MinimumASTNodeFinder(node.getLineNumber(), cu);
+                cu.accept(finder);
+                ASTNode astNode = finder.getMinimumNode();
 
-					TraceNode stepOverPrev = node.getStepOverPrevious();
-					while (stepOverPrev != null && start <= stepOverPrev.getLineNumber()
-							&& stepOverPrev.getLineNumber() <= end) {
-						List<VarValue> readVars = stepOverPrev.getReadVariables();
-						for (VarValue readVar : readVars) {
-							if (!node.getReadVariables().contains(readVar)) {
-								node.getReadVariables().add(readVar);
-							}
-						}
-						stepOverPrev = stepOverPrev.getStepOverPrevious();
-					}
-				}
+                if (astNode != null) {
+                    int start = cu.getLineNumber(astNode.getStartPosition());
+                    int end = cu.getLineNumber(astNode.getStartPosition() + astNode.getLength());
 
-			}
-		}
-	}
+                    TraceNode stepOverPrev = node.getStepOverPrevious();
+                    while (stepOverPrev != null && start <= stepOverPrev.getLineNumber()
+                            && stepOverPrev.getLineNumber() <= end) {
+                        List<VarValue> readVars = stepOverPrev.getReadVariables();
+                        for (VarValue readVar : readVars) {
+                            if (!node.getReadVariables().contains(readVar)) {
+                                node.getReadVariables().add(readVar);
+                            }
+                        }
+                        stepOverPrev = stepOverPrev.getStepOverPrevious();
+                    }
+                }
 
-	private CompilationUnit getCompilationUnit(Path path) throws IOException {
-		String pathStr = path.toString();
-		if (pathToCompilationUnitMap.containsKey(pathStr))
-			return pathToCompilationUnitMap.get(pathStr);
-		String fileContent = Files.readString(path);
-		CompilationUnit cu = parseCompilationUnit(fileContent);
-		pathToCompilationUnitMap.put(pathStr, cu);
-		return cu;
+            }
+        }
+    }
 
-	}
+    private CompilationUnit getCompilationUnit(Path path) throws IOException {
+        String pathStr = path.toString();
+        if (pathToCompilationUnitMap.containsKey(pathStr))
+            return pathToCompilationUnitMap.get(pathStr);
+        String fileContent = Files.readString(path);
+        CompilationUnit cu = parseCompilationUnit(fileContent);
+        pathToCompilationUnitMap.put(pathStr, cu);
+        return cu;
 
-	private CompilationUnit parseCompilationUnit(String fileContent) {
-		ASTParser parser = ASTParser.newParser(AST.getJLSLatest()); // handles JDK 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6
-		parser.setSource(fileContent.toCharArray());
-		parser.setResolveBindings(true);
-		// In order to parse 1.6 code, some compiler options need to be set to 1.6
-		Map<String, String> options = JavaCore.getOptions();
-		JavaCore.setComplianceOptions(JavaCore.VERSION_1_8, options);
-		parser.setCompilerOptions(options);
+    }
 
-		return (CompilationUnit) parser.createAST(null);
-	}
+    private CompilationUnit parseCompilationUnit(String fileContent) {
+        ASTParser parser = ASTParser.newParser(AST.getJLSLatest()); // handles JDK 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6
+        parser.setSource(fileContent.toCharArray());
+        parser.setResolveBindings(true);
+        // In order to parse 1.6 code, some compiler options need to be set to 1.6
+        Map<String, String> options = JavaCore.getOptions();
+        JavaCore.setComplianceOptions(JavaCore.VERSION_1_8, options);
+        parser.setCompilerOptions(options);
 
-	private PairList createPairList(Trace buggyTrace, Trace workingTrace, String buggyPath, String workingPath) {
-		DiffMatcher diffMatcher = new DiffMatcher(SRC_DIR, TEST_DIR, buggyPath, workingPath);
-		diffMatcher.matchCode();
-		ControlPathBasedTraceMatcher traceMatcher = new ControlPathBasedTraceMatcher();
-		PairList pairList = traceMatcher.matchTraceNodePair(buggyTrace, workingTrace, diffMatcher);
-		return pairList;
-	}
-	
-	private List<NodeVarValPair> createNodeVarValPairsFromNodeAndVarVals(TraceNode node, boolean isRead) {
-	    List<NodeVarValPair> result = new ArrayList<>();
-	    List<VarValue> varValues = isRead ? node.getReadVariables() : node.getWrittenVariables();
-	    for (VarValue varVal : varValues) {
-	        result.add(new NodeVarValPair(node, varVal));
-	    }
-	    return result;
-	}
+        return (CompilationUnit) parser.createAST(null);
+    }
+
+    private PairList createPairList(Trace buggyTrace, Trace workingTrace, String buggyPath, String workingPath) {
+        DiffMatcher diffMatcher = new DiffMatcher(SRC_DIR, TEST_DIR, buggyPath, workingPath);
+        diffMatcher.matchCode();
+        ControlPathBasedTraceMatcher traceMatcher = new ControlPathBasedTraceMatcher();
+        PairList pairList = traceMatcher.matchTraceNodePair(buggyTrace, workingTrace, diffMatcher);
+        return pairList;
+    }
+
+    private List<NodeVarValPair> createNodeVarValPairsFromNodeAndVarVals(TraceNode node, boolean isRead) {
+        List<NodeVarValPair> result = new ArrayList<>();
+        List<VarValue> varValues = isRead ? node.getReadVariables() : node.getWrittenVariables();
+        for (VarValue varVal : varValues) {
+            result.add(new NodeVarValPair(node, varVal));
+        }
+        return result;
+    }
 }

--- a/tregression/test-dir/test/iodetection/IOReaderIT.java
+++ b/tregression/test-dir/test/iodetection/IOReaderIT.java
@@ -3,12 +3,16 @@ package iodetection;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import iodetection.IOReader.IOResult;
 
 import static iodetection.IOWriterIT.TEMP_FILE_NAME;
 import static iodetection.IOWriterIT.SAMPLE_FILE_CONTENT;
@@ -27,11 +31,18 @@ class IOReaderIT {
 	private Path tempDir;
 
 	private Path tempFile;
+	
+	private List<IOResult> expectedInputs;
+	private IOResult expectedOutput;
 
 	@BeforeEach
 	void setUp() {
 		reader = new IOReader();
 		tempFile = tempDir.resolve(TEMP_FILE_NAME);
+		expectedInputs = new ArrayList<>();
+		expectedInputs.add(new IOResult(String.format(INPUT_VAR_ID_FMT, 1), 1));
+        expectedInputs.add(new IOResult(String.format(INPUT_VAR_ID_FMT, 2), 2));
+        expectedOutput = new IOResult(OUTPUT_VAR_ID, 1);
 	}
 
 	@Nested
@@ -39,26 +50,22 @@ class IOReaderIT {
 		@Test
 		void readInputs_FileWithInputsAndOutputs_GetsInputsCorrectly() throws IOException {
 			Files.writeString(tempFile, SAMPLE_FILE_CONTENT);
-			String[] inputs = reader.readInputs(tempFile).get();
-			String[] expectedInputs = new String[] { String.format(INPUT_VAR_ID_FMT, 1),
-					String.format(INPUT_VAR_ID_FMT, 2) };
-			assertArrayEquals(expectedInputs, inputs);
+			List<IOResult> inputs = reader.readInputs(tempFile).get();
+			assertEquals(expectedInputs, inputs);
 		}
 
 		@Test
 		void readInputs_FileWithNoInputs_GetsInputsCorrectly() throws IOException {
 			Files.writeString(tempFile, System.lineSeparator() + SAMPLE_OUTPUT_CONTENT);
-			Optional<String[]> inputs = reader.readInputs(tempFile);
+			Optional<List<IOResult>> inputs = reader.readInputs(tempFile);
 			assertTrue(inputs.isEmpty());
 		}
 
 		@Test
 		void readInputs_FileWithNoOutputs_GetsInputsCorrectly() throws IOException {
 			Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
-			String[] inputs = reader.readInputs(tempFile).get();
-			String[] expectedInputs = new String[] { String.format(INPUT_VAR_ID_FMT, 1),
-					String.format(INPUT_VAR_ID_FMT, 2) };
-			assertArrayEquals(expectedInputs, inputs);
+            List<IOResult> inputs = reader.readInputs(tempFile).get();
+			assertEquals(expectedInputs, inputs);
 		}
 	}
 
@@ -67,21 +74,21 @@ class IOReaderIT {
 		@Test
 		void readOutput_FileWithInputsAndOutputs_GetsOutputCorrectly() throws IOException {
 			Files.writeString(tempFile, SAMPLE_FILE_CONTENT);
-			String output = reader.readOutput(tempFile).get();
-			assertEquals(OUTPUT_VAR_ID, output);
+			IOResult output = reader.readOutput(tempFile).get();
+			assertEquals(expectedOutput, output);
 		}
 
 		@Test
 		void readOutput_FileWithNoInputs_GetsOutputCorrectly() throws IOException {
 			Files.writeString(tempFile, System.lineSeparator() + SAMPLE_OUTPUT_CONTENT);
-			String output = reader.readOutput(tempFile).get();
-			assertEquals(OUTPUT_VAR_ID, output);
+			IOResult output = reader.readOutput(tempFile).get();
+			assertEquals(expectedOutput, output);
 		}
 
 		@Test
 		void readOutput_FileWithNoOutputs_GetsOutputCorrectly() throws IOException {
 			Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
-			Optional<String> output = reader.readOutput(tempFile);
+			Optional<IOResult> output = reader.readOutput(tempFile);
 			assertTrue(output.isEmpty());
 		}
 	}

--- a/tregression/test-dir/test/iodetection/IOReaderIT.java
+++ b/tregression/test-dir/test/iodetection/IOReaderIT.java
@@ -15,81 +15,90 @@ import org.junit.jupiter.api.io.TempDir;
 import iodetection.IOReader.IOResult;
 
 import static iodetection.IOWriterIT.TEMP_FILE_NAME;
-import static iodetection.IOWriterIT.SAMPLE_FILE_CONTENT;
+import static iodetection.IOWriterIT.SAMPLE_WRONG_VAR_VAL_FILE_CONTENT;
+import static iodetection.IOWriterIT.SAMPLE_WRONG_BRANCH_FILE_CONTENT;
 import static iodetection.IOWriterIT.INPUT_VAR_ID_FMT;
 import static iodetection.IOWriterIT.OUTPUT_VAR_ID;
-import static iodetection.IOWriterIT.SAMPLE_OUTPUT_CONTENT;
+import static iodetection.IOWriterIT.SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT;
 import static iodetection.IOWriterIT.SAMPLE_INPUT_CONTENT;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IOReaderIT {
-	private IOReader reader;
-	@TempDir
-	private Path tempDir;
+    private IOReader reader;
+    @TempDir
+    private Path tempDir;
 
-	private Path tempFile;
-	
-	private List<IOResult> expectedInputs;
-	private IOResult expectedOutput;
+    private Path tempFile;
 
-	@BeforeEach
-	void setUp() {
-		reader = new IOReader();
-		tempFile = tempDir.resolve(TEMP_FILE_NAME);
-		expectedInputs = new ArrayList<>();
-		expectedInputs.add(new IOResult(String.format(INPUT_VAR_ID_FMT, 1), 1));
+    private List<IOResult> expectedInputs;
+    private IOResult expectedWrongVarValOutput;
+    private IOResult expectedWrongBranchOutput;
+
+    @BeforeEach
+    void setUp() {
+        reader = new IOReader();
+        tempFile = tempDir.resolve(TEMP_FILE_NAME);
+        expectedInputs = new ArrayList<>();
+        expectedInputs.add(new IOResult(String.format(INPUT_VAR_ID_FMT, 1), 1));
         expectedInputs.add(new IOResult(String.format(INPUT_VAR_ID_FMT, 2), 2));
-        expectedOutput = new IOResult(OUTPUT_VAR_ID, 1);
-	}
+        expectedWrongVarValOutput = new IOResult(OUTPUT_VAR_ID, 1);
+        expectedWrongBranchOutput = new IOResult(null, 1);
+    }
 
-	@Nested
-	class ReadInputs {
-		@Test
-		void readInputs_FileWithInputsAndOutputs_GetsInputsCorrectly() throws IOException {
-			Files.writeString(tempFile, SAMPLE_FILE_CONTENT);
-			List<IOResult> inputs = reader.readInputs(tempFile).get();
-			assertEquals(expectedInputs, inputs);
-		}
-
-		@Test
-		void readInputs_FileWithNoInputs_GetsInputsCorrectly() throws IOException {
-			Files.writeString(tempFile, System.lineSeparator() + SAMPLE_OUTPUT_CONTENT);
-			Optional<List<IOResult>> inputs = reader.readInputs(tempFile);
-			assertTrue(inputs.isEmpty());
-		}
-
-		@Test
-		void readInputs_FileWithNoOutputs_GetsInputsCorrectly() throws IOException {
-			Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
+    @Nested
+    class ReadInputs {
+        @Test
+        void readInputs_FileWithInputsAndOutputs_GetsInputsCorrectly() throws IOException {
+            Files.writeString(tempFile, SAMPLE_WRONG_VAR_VAL_FILE_CONTENT);
             List<IOResult> inputs = reader.readInputs(tempFile).get();
-			assertEquals(expectedInputs, inputs);
-		}
-	}
+            assertEquals(expectedInputs, inputs);
+        }
 
-	@Nested
-	class ReadOutput {
-		@Test
-		void readOutput_FileWithInputsAndOutputs_GetsOutputCorrectly() throws IOException {
-			Files.writeString(tempFile, SAMPLE_FILE_CONTENT);
-			IOResult output = reader.readOutput(tempFile).get();
-			assertEquals(expectedOutput, output);
-		}
+        @Test
+        void readInputs_FileWithNoInputs_GetsInputsCorrectly() throws IOException {
+            Files.writeString(tempFile, System.lineSeparator() + SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT);
+            Optional<List<IOResult>> inputs = reader.readInputs(tempFile);
+            assertTrue(inputs.isEmpty());
+        }
 
-		@Test
-		void readOutput_FileWithNoInputs_GetsOutputCorrectly() throws IOException {
-			Files.writeString(tempFile, System.lineSeparator() + SAMPLE_OUTPUT_CONTENT);
-			IOResult output = reader.readOutput(tempFile).get();
-			assertEquals(expectedOutput, output);
-		}
+        @Test
+        void readInputs_FileWithNoOutputs_GetsInputsCorrectly() throws IOException {
+            Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
+            List<IOResult> inputs = reader.readInputs(tempFile).get();
+            assertEquals(expectedInputs, inputs);
+        }
+    }
 
-		@Test
-		void readOutput_FileWithNoOutputs_GetsOutputCorrectly() throws IOException {
-			Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
-			Optional<IOResult> output = reader.readOutput(tempFile);
-			assertTrue(output.isEmpty());
-		}
-	}
+    @Nested
+    class ReadOutput {
+        @Test
+        void readOutput_FileWithInputsAndWrongVarValueOutput_GetsOutputCorrectly() throws IOException {
+            Files.writeString(tempFile, SAMPLE_WRONG_VAR_VAL_FILE_CONTENT);
+            IOResult output = reader.readOutput(tempFile).get();
+            assertEquals(expectedWrongVarValOutput, output);
+        }
+
+        @Test
+        void readOutput_FileWithInputsAndWrongBranchOutput_GetsOutputCorrectly() throws IOException {
+            Files.writeString(tempFile, SAMPLE_WRONG_BRANCH_FILE_CONTENT);
+            IOResult output = reader.readOutput(tempFile).get();
+            assertEquals(expectedWrongBranchOutput, output);
+        }
+
+        @Test
+        void readOutput_FileWithNoInputs_GetsOutputCorrectly() throws IOException {
+            Files.writeString(tempFile, System.lineSeparator() + SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT);
+            IOResult output = reader.readOutput(tempFile).get();
+            assertEquals(expectedWrongVarValOutput, output);
+        }
+
+        @Test
+        void readOutput_FileWithNoOutput_GetsOutputCorrectly() throws IOException {
+            Files.writeString(tempFile, SAMPLE_INPUT_CONTENT + System.lineSeparator());
+            Optional<IOResult> output = reader.readOutput(tempFile);
+            assertTrue(output.isEmpty());
+        }
+    }
 }

--- a/tregression/test-dir/test/iodetection/IOWriterIT.java
+++ b/tregression/test-dir/test/iodetection/IOWriterIT.java
@@ -10,109 +10,122 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import iodetection.IODetector.NodeVarValPair;
+import microbat.model.trace.TraceNode;
 import microbat.model.value.GraphNode;
 import microbat.model.value.VarValue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class IOWriterIT {
-	static final String TEMP_FILE_NAME = "io.txt";
-	static final String INPUT_VAR_ID_FMT = "input-%d";
-	static final String OUTPUT_VAR_ID = "output-1";
-	static final String SAMPLE_INPUT_CONTENT = String.format(INPUT_VAR_ID_FMT, 1) + " "
-			+ String.format(INPUT_VAR_ID_FMT, 2) + System.lineSeparator();
-	static final String SAMPLE_OUTPUT_CONTENT = OUTPUT_VAR_ID + System.lineSeparator();;
-	static final String SAMPLE_FILE_CONTENT = SAMPLE_INPUT_CONTENT + SAMPLE_OUTPUT_CONTENT;
+    static final String TEMP_FILE_NAME = "io.txt";
+    static final String INPUT_VAR_ID_FMT = "input-%d";
+    static final String OUTPUT_VAR_ID = "output-1";
+    static final String SAMPLE_INPUT_CONTENT = String.join(" ", String.format(INPUT_VAR_ID_FMT, 1), "1", 
+            String.format(INPUT_VAR_ID_FMT, 2), "2") + System.lineSeparator();
+    static final String SAMPLE_OUTPUT_CONTENT = OUTPUT_VAR_ID + " " + 1 + System.lineSeparator();;
+    static final String SAMPLE_FILE_CONTENT = SAMPLE_INPUT_CONTENT + SAMPLE_OUTPUT_CONTENT;
 
-	private IOWriter writer;
+    private IOWriter writer;
 
-	@TempDir
-	private Path tempDir;
+    @TempDir
+    private Path tempDir;
 
-	private Path tempFile;
+    private Path tempFile;
 
-	private List<VarValue> inputs;
-	private VarValue output;
+    private List<NodeVarValPair> inputs;
+    private NodeVarValPair output;
 
-	@BeforeEach
-	void setUp() {
-		writer = new IOWriter();
-		tempFile = tempDir.resolve(TEMP_FILE_NAME);
+    @BeforeEach
+    void setUp() {
+        writer = new IOWriter();
+        tempFile = tempDir.resolve(TEMP_FILE_NAME);
 
-		inputs = new ArrayList<>();
-		inputs.add(new VarValueStub(String.format(INPUT_VAR_ID_FMT, 1)));
-		inputs.add(new VarValueStub(String.format(INPUT_VAR_ID_FMT, 2)));
-		output = new VarValueStub(OUTPUT_VAR_ID);
-	}
+        inputs = new ArrayList<>();
+        inputs.add(createNodeVarValPair(1));
+        inputs.add(createNodeVarValPair(2));
+        
+        TraceNode outputNode = new TraceNode();
+        outputNode.setOrder(1);
+        VarValue varValue = new VarValueStub(OUTPUT_VAR_ID);
+        output = new NodeVarValPair(outputNode, varValue);
+    }
 
-	@Test
-	void writeIO_InputsAndOutputProvided_WritesIO() throws IOException {
-		writer.writeIO(inputs, output, tempFile);
-		String fileContents = Files.readString(tempFile);
-		assertEquals(SAMPLE_FILE_CONTENT, fileContents);
-	}
+    private NodeVarValPair createNodeVarValPair(int id) {
+        TraceNode node = new TraceNode();
+        node.setOrder(id);
+        VarValue varValue = new VarValueStub(String.format(INPUT_VAR_ID_FMT, id));
+        return new NodeVarValPair(node, varValue);
+    }
 
-	@Test
-	void writeIO_InputsIsEmpty_WritesOutputCorrectly() throws IOException {
-		inputs = new ArrayList<>();
-		writer.writeIO(inputs, output, tempFile);
-		String fileContents = Files.readString(tempFile);
-		assertEquals(System.lineSeparator() + SAMPLE_OUTPUT_CONTENT, fileContents);
-	}
+    @Test
+    void writeIO_InputsAndOutputProvided_WritesIO() throws IOException {
+        writer.writeIO(inputs, output, tempFile);
+        String fileContents = Files.readString(tempFile);
+        assertEquals(SAMPLE_FILE_CONTENT, fileContents);
+    }
 
-	@Test
-	void writeIO_oUTPUTIsEmpty_WritesInputsCorrectly() throws IOException {
-		output = null;
-		writer.writeIO(inputs, output, tempFile);
-		String fileContents = Files.readString(tempFile);
-		assertEquals(SAMPLE_INPUT_CONTENT + System.lineSeparator(), fileContents);
-	}
+    @Test
+    void writeIO_InputsIsEmpty_WritesOutputCorrectly() throws IOException {
+        inputs = new ArrayList<>();
+        writer.writeIO(inputs, output, tempFile);
+        String fileContents = Files.readString(tempFile);
+        assertEquals(System.lineSeparator() + SAMPLE_OUTPUT_CONTENT, fileContents);
+    }
 
-	@Test
-	void writeIO_WritesMultipleTimes_Overwrites() throws IOException {
-		int count = 3;
-		for (int i = 0; i < count; i++) {
-			writer.writeIO(inputs, output, tempFile);
-		}
-		String fileContents = Files.readString(tempFile);
-		assertEquals(SAMPLE_FILE_CONTENT, fileContents);
-	}
+    @Test
+    void writeIO_OutputIsEmpty_WritesInputsCorrectly() throws IOException {
+        output = null;
+        writer.writeIO(inputs, output, tempFile);
+        String fileContents = Files.readString(tempFile);
+        assertEquals(SAMPLE_INPUT_CONTENT + System.lineSeparator(), fileContents);
+    }
 
-	/**
-	 * We could use Mockito in the future.
-	 *
-	 */
-	private class VarValueStub extends VarValue {
-		private static final long serialVersionUID = 1L;
-		private final String varID;
+    @Test
+    void writeIO_WritesMultipleTimes_Overwrites() throws IOException {
+        int count = 3;
+        for (int i = 0; i < count; i++) {
+            writer.writeIO(inputs, output, tempFile);
+        }
+        String fileContents = Files.readString(tempFile);
+        assertEquals(SAMPLE_FILE_CONTENT, fileContents);
+    }
 
-		public VarValueStub(String varID) {
-			super();
-			this.varID = varID;
-		}
+    /**
+     * We could use Mockito in the future.
+     *
+     */
+    private class VarValueStub extends VarValue {
+        private static final long serialVersionUID = 1L;
+        private final String varID;
 
-		@Override
-		public String getVarID() {
-			return varID;
-		}
+        public VarValueStub(String varID) {
+            super();
+            this.varID = varID;
+        }
 
-		@Override
-		public boolean isTheSameWith(GraphNode node) {
-			// TODO Auto-generated method stub
-			return false;
-		}
+        @Override
+        public String getVarID() {
+            return varID;
+        }
 
-		@Override
-		public VarValue clone() {
-			// TODO Auto-generated method stub
-			return null;
-		}
+        @Override
+        public boolean isTheSameWith(GraphNode node) {
+            // TODO Auto-generated method stub
+            return false;
+        }
 
-		@Override
-		public String getHeapID() {
-			// TODO Auto-generated method stub
-			return null;
-		}
+        @Override
+        public VarValue clone() {
+            // TODO Auto-generated method stub
+            return null;
+        }
 
-	}
+        @Override
+        public String getHeapID() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+    }
 }

--- a/tregression/test-dir/test/iodetection/IOWriterIT.java
+++ b/tregression/test-dir/test/iodetection/IOWriterIT.java
@@ -23,8 +23,9 @@ class IOWriterIT {
     static final String OUTPUT_VAR_ID = "output-1";
     static final String SAMPLE_INPUT_CONTENT = String.join(" ", String.format(INPUT_VAR_ID_FMT, 1), "1", 
             String.format(INPUT_VAR_ID_FMT, 2), "2") + System.lineSeparator();
-    static final String SAMPLE_OUTPUT_CONTENT = OUTPUT_VAR_ID + " " + 1 + System.lineSeparator();;
-    static final String SAMPLE_FILE_CONTENT = SAMPLE_INPUT_CONTENT + SAMPLE_OUTPUT_CONTENT;
+    static final String SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT = OUTPUT_VAR_ID + " " + 1 + System.lineSeparator();;
+    static final String SAMPLE_WRONG_VAR_VAL_FILE_CONTENT = SAMPLE_INPUT_CONTENT + SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT;
+    static final String SAMPLE_WRONG_BRANCH_FILE_CONTENT = SAMPLE_INPUT_CONTENT + 1 + System.lineSeparator();
 
     private IOWriter writer;
 
@@ -34,7 +35,8 @@ class IOWriterIT {
     private Path tempFile;
 
     private List<NodeVarValPair> inputs;
-    private NodeVarValPair output;
+    private NodeVarValPair wrongVarValOutput;
+    private NodeVarValPair wrongBranchOutput;
 
     @BeforeEach
     void setUp() {
@@ -48,7 +50,8 @@ class IOWriterIT {
         TraceNode outputNode = new TraceNode();
         outputNode.setOrder(1);
         VarValue varValue = new VarValueStub(OUTPUT_VAR_ID);
-        output = new NodeVarValPair(outputNode, varValue);
+        wrongVarValOutput = new NodeVarValPair(outputNode, varValue);
+        wrongBranchOutput = new NodeVarValPair(outputNode, null);
     }
 
     private NodeVarValPair createNodeVarValPair(int id) {
@@ -59,24 +62,31 @@ class IOWriterIT {
     }
 
     @Test
-    void writeIO_InputsAndOutputProvided_WritesIO() throws IOException {
-        writer.writeIO(inputs, output, tempFile);
+    void writeIO_InputsAndWrongVarValOutputProvided_WritesIO() throws IOException {
+        writer.writeIO(inputs, wrongVarValOutput, tempFile);
         String fileContents = Files.readString(tempFile);
-        assertEquals(SAMPLE_FILE_CONTENT, fileContents);
+        assertEquals(SAMPLE_WRONG_VAR_VAL_FILE_CONTENT, fileContents);
+    }
+    
+    @Test
+    void writeIO_InputsAndWrongBranchOutputProvided_WritesIO() throws IOException {
+        writer.writeIO(inputs, wrongBranchOutput, tempFile);
+        String fileContents = Files.readString(tempFile);
+        assertEquals(SAMPLE_WRONG_BRANCH_FILE_CONTENT, fileContents);
     }
 
     @Test
     void writeIO_InputsIsEmpty_WritesOutputCorrectly() throws IOException {
         inputs = new ArrayList<>();
-        writer.writeIO(inputs, output, tempFile);
+        writer.writeIO(inputs, wrongVarValOutput, tempFile);
         String fileContents = Files.readString(tempFile);
-        assertEquals(System.lineSeparator() + SAMPLE_OUTPUT_CONTENT, fileContents);
+        assertEquals(System.lineSeparator() + SAMPLE_WRONG_VAR_VAL_OUTPUT_CONTENT, fileContents);
     }
 
     @Test
     void writeIO_OutputIsEmpty_WritesInputsCorrectly() throws IOException {
-        output = null;
-        writer.writeIO(inputs, output, tempFile);
+        wrongVarValOutput = null;
+        writer.writeIO(inputs, wrongVarValOutput, tempFile);
         String fileContents = Files.readString(tempFile);
         assertEquals(SAMPLE_INPUT_CONTENT + System.lineSeparator(), fileContents);
     }
@@ -85,10 +95,10 @@ class IOWriterIT {
     void writeIO_WritesMultipleTimes_Overwrites() throws IOException {
         int count = 3;
         for (int i = 0; i < count; i++) {
-            writer.writeIO(inputs, output, tempFile);
+            writer.writeIO(inputs, wrongVarValOutput, tempFile);
         }
         String fileContents = Files.readString(tempFile);
-        assertEquals(SAMPLE_FILE_CONTENT, fileContents);
+        assertEquals(SAMPLE_WRONG_VAR_VAL_FILE_CONTENT, fileContents);
     }
 
     /**


### PR DESCRIPTION
# Description
Update IODetector:
- Add Trace Node order number to inputs and outputs
- Check for corresponding node in correct branch for obtaining "Wrong Branch" as output
- Update Reader and Writer
- Add corresponding tests

# Usage
`IOReader` returns an `IOResult` object that contains the Trace Node number and Var ID of the variable with wrong value. The Var ID is null if it is a wrong branch.